### PR TITLE
Added RAG Web Browser to MCP servers

### DIFF
--- a/src/data/mcp/data.json
+++ b/src/data/mcp/data.json
@@ -162,6 +162,7 @@
   {
     "name": "Apify RAG Web Browser",
     "url": "https://apify.com/apify/rag-web-browser#anthropic-model-context-protocol-mcp-server",
-    "description": "Web browser for LLM apps similar to a web browser in ChatGPT. It queries Google Search, scrapes the top N pages from the results, and returns their cleaned content as Markdown."
+    "description": "Web browser for LLM apps similar to a web browser in ChatGPT. It queries Google Search, scrapes the top N pages from the results, and returns their cleaned content as Markdown.",
+    "logo": "https://apify.com/ext/apify-symbol-512px.svg"
   }
 ]

--- a/src/data/mcp/data.json
+++ b/src/data/mcp/data.json
@@ -158,5 +158,10 @@
     "name": "BrowserTools MCP",
     "url": "https://github.com/AgentDeskAI/browser-tools-mcp",
     "description": "Analyze logs & interact with your browser for rapid debugging"
+  },
+  {
+    "name": "Apify RAG Web Browser",
+    "url": "https://apify.com/apify/rag-web-browser#anthropic-model-context-protocol-mcp-server",
+    "description": "Web browser for LLM apps similar to a web browser in ChatGPT. It queries Google Search, scrapes the top N pages from the results, and returns their cleaned content as Markdown."
   }
 ]


### PR DESCRIPTION
Added https://apify.com/apify/rag-web-browser, which is an equivalent of ChatGPT's web browser which can be used from Cursor.