### PR TITLE
Update stripe mcp agent link

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -60,7 +60,7 @@ export default [
   },
   {
     name: "Stripe",
-    url: "https://github.com/stripe/agent-toolkit",
+    url: "https://github.com/stripe/agent-toolkit/tree/main/modelcontextprotocol",
     description: "Interact with the Stripe API",
     logo: "https://cdn.brandfetch.io/idxAg10C0L/theme/light/logo.svg?c=1dxbfHSJFAPEGdCLU4o5B"
   },


### PR DESCRIPTION
Hi! We made an easier install flow for the Stripe MCP server. This is updating the link it points to.


(The MCP server in action: https://x.com/StripeDev/status/1892685153987592526)