### PR TITLE
Fix: add correct fallback for next URL Param in redirect path for GitHub and Google sign-in components

### DIFF
--- a/apps/cursor/src/components/github-signin.tsx
+++ b/apps/cursor/src/components/github-signin.tsx
@@ -8,7 +8,7 @@ import { Button } from "./ui/button";
 export function GithubSignin() {
   const supabase = createClient();
   const searchParams = useSearchParams();
-  const next = searchParams.get("next");
+  const next = searchParams.get("next") ?? "/";
 
   return (
     <Button

--- a/apps/cursor/src/components/google-signin.tsx
+++ b/apps/cursor/src/components/google-signin.tsx
@@ -7,7 +7,7 @@ import { Button } from "./ui/button";
 export function GoogleSignin() {
   const supabase = createClient();
   const searchParams = useSearchParams();
-  const next = searchParams.get("next");
+  const next = searchParams.get("next") ?? "/";
 
   return (
     <Button

--- a/apps/windsurf/src/components/github-signin.tsx
+++ b/apps/windsurf/src/components/github-signin.tsx
@@ -8,7 +8,7 @@ import { Button } from "./ui/button";
 export function GithubSignin() {
   const supabase = createClient();
   const searchParams = useSearchParams();
-  const next = searchParams.get("next");
+  const next = searchParams.get("next") ?? "/";
 
   return (
     <Button

--- a/apps/windsurf/src/components/google-signin.tsx
+++ b/apps/windsurf/src/components/google-signin.tsx
@@ -7,7 +7,7 @@ import { Button } from "./ui/button";
 export function GoogleSignin() {
   const supabase = createClient();
   const searchParams = useSearchParams();
-  const next = searchParams.get("next");
+  const next = searchParams.get("next") ?? "/";
 
   return (
     <Button


### PR DESCRIPTION
In some cases we are not getting properly the `next` url param using the `useSearchParams` hook **during the SignIn**, facing this on IOS small screens for some reason (see screenshot). 

Pushed a possible fix to ensure that `null` values are not propagated to the auth callback API endpoint. The API endpoint contains the correct fallback/protection however when using `searchParams.get("next")` if the parameter is next=null in the URL, it will return the string "null".

<img width="404" alt="image" src="https://github.com/user-attachments/assets/45183ab9-19f8-4e6a-8715-ccda76693afe" />
