### PR TITLE
feat: add the SettleMint MCP

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -228,4 +228,11 @@ export default [
     description:
       "A Model Context Protocol (MCP) server that enables AI assistants like Claude to interact with your Inbox Zero account. This allows for natural language querying and management of your email during conversations.",
   },
+    {
+    name: "SettleMint",
+    url: "https://console.settlemint.com/documentation/building-with-settlemint/dev-tools/mcp",
+    description:
+      "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
+    logo: "https://console.settlemint.com/android-chrome-512x512.png",
+  },
 ];


### PR DESCRIPTION
This pull request includes an addition to the `packages/data/src/mcp/index.ts` file. The change adds a new entry for "SettleMint" to the list of MCP servers, including its name, URL, description, and logo.

* [`packages/data/src/mcp/index.ts`](diffhunk://#diff-325d49686f91b32c43e6f6c9b8dac6b0fcf7b8f133ae38db6e8aa946dbee9263R231-R237): Added "SettleMint" MCP server entry with details such as name, URL, description, and logo.