### PR TITLE
Feat: Add Hyperbrowser MCP to directory

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -233,11 +233,17 @@ export default [
     description:
       "A Model Context Protocol (MCP) server that enables AI assistants like Claude to interact with your Inbox Zero account. This allows for natural language querying and management of your email during conversations.",
   },
-    {
+  {
     name: "SettleMint",
     url: "https://console.settlemint.com/documentation/building-with-settlemint/dev-tools/mcp",
     description:
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "Hyperbrowser",
+    url: "https://github.com/hyperbrowserai/mcp",
+    description: "Cloud Browsers for AI Agents. Scrape, navigate, and interact with the web using Hyperbrowser's Model Context Protocol (MCP) servers.",
+    logo: "https://hyperbrowser.ai/hb-logo.png",
+  }
 ];


### PR DESCRIPTION
Added to Hyperbrowser's MCP to `packages/data/src/mcp/index.ts`

(I'm the Founder of Hyperbrowser)