### PR TITLE
Add prompt for Git Commit message rules

### DIFF
--- a/packages/data/src/rules/gitcommit.ts
+++ b/packages/data/src/rules/gitcommit.ts
@@ -1,0 +1,25 @@
+export const gitcommitRules = [
+  {
+    title: "Git Commit Rules",
+    tags: ["Git", "Commit", "VCS"],
+    libs: ["Git", "VCS", "GitHub", "GitLab", "Bitbucket"],
+    slug: "git-commit-cursor-rules",
+    author: {
+      name: "Lukas Wolfsteiner",
+      url: "https://lukas.wolfsteiner.media/links/github?ref=cursor-rules",
+      avatar: "https://lukas.wolfsteiner.media/assets/img/photo.jpg",
+    },
+    content: `
+Commit Messages must have a short description that is less than 50 characters followed by a newline and a more detailed description.
+- Commit message should have one of the following prefixes: "feat: ", "fix: ", "refactor: "
+- Use markdown syntax
+- Write concisely using an informal tone
+- List significant changes
+- Do not use specific names or files from the code
+- Do not use phrases like "this commit", "this change", etc.
+- Sentences in the detailed description should be separated by newlines
+- Mention implications and possible usages of the code changes
+- Do not respond as code with \`\`\` at the end of the message
+    `
+  },
+];

--- a/packages/data/src/rules/index.ts
+++ b/packages/data/src/rules/index.ts
@@ -28,6 +28,7 @@ import { flutterRules } from "./flutter";
 import { frontEndRules } from "./front-end";
 import { gatsbyRules } from "./gastby";
 import { ghostTailwindcssRules } from "./ghost-tailwindcss";
+import { gitcommitRules } from "./gitcommit";
 import { globalRules } from "./global";
 import { goRules } from "./go";
 import { htmlAndCssRules } from "./htmlandcss";
@@ -108,6 +109,7 @@ export const rules: Rule[] = [
   ...frontEndRules,
   ...gatsbyRules,
   ...ghostTailwindcssRules,
+  ...gitcommitRules,
   ...globalRules,
   ...goRules,
   ...htmlAndCssRules,


### PR DESCRIPTION
This pull request adds a new set of rules for writing Git commit messages and integrates them into the existing rules system, the main focus is on ensuring that commit messages follow specific formatting and content guidelines.

**Addition of Git commit rules:**

* Introduced a new `gitcommitRules` array in `gitcommit.ts`, which defines best practices for writing Git commit messages, such as using specific prefixes, markdown syntax, concise language, and avoiding code/file names.

**Integration with the rules system:**

* Updated `index.ts` to import the new `gitcommitRules` and include them in the exported `rules` array, making these guidelines available alongside other rule sets. [[1]](diffhunk://#diff-fa90387c03ab017bbf472f75a909b964014e3ef1f20e32f066806a7f52d06fb3R31) [[2]](diffhunk://#diff-fa90387c03ab017bbf472f75a909b964014e3ef1f20e32f066806a7f52d06fb3R112)