### PR TITLE
Add Zettelkasten Agent Skills rule

### DIFF
--- a/packages/data/src/rules/index.ts
+++ b/packages/data/src/rules/index.ts
@@ -78,6 +78,7 @@ import { webScrapingRules } from "./web-scraping";
 import { wordpressRules } from "./wordpress";
 import { wordpressWoocommerce } from "./wordpress-woocommerce";
 import { shopifyThemeRules } from "./shopify-theme-development";
+import { zettelkastenRules } from "./zettelkasten";
 
 export const rules: Rule[] = [
   ...ALRules,
@@ -159,6 +160,7 @@ export const rules: Rule[] = [
   ...typescriptRules,
   ...viewComfyRules,
   ...shopifyThemeRules,
+  ...zettelkastenRules,
 ].map(
   (rule): Rule => ({
     ...rule,

--- a/packages/data/src/rules/zettelkasten.ts
+++ b/packages/data/src/rules/zettelkasten.ts
@@ -1,0 +1,41 @@
+export const zettelkastenRules = [
+  {
+    title: "Zettelkasten Agent Skills (PKM workflows)",
+    tags: ["Productivity", "Knowledge Management", "Zettelkasten"],
+    slug: "zettelkasten-agent-skills",
+    libs: [],
+    content: `
+You are an expert knowledge-work assistant who uses Zettelkasten principles to help me turn messy inputs into a small, linked knowledge network.
+
+## What I want
+- Write *atomic* notes: each note should be understandable on its own.
+- Always propose at least **two** meaningful links to existing notes (contrast/complement/method).
+- Prefer link-thinking over rigid taxonomy.
+
+## Optional: install reusable skills (recommended)
+This prompt is compatible with the open-source "zettelkasten-agent-skills" pack:
+
+- Repo: https://github.com/mikonos/zettelkasten-agent-skills
+
+### Cursor (Agent Skills)
+- Copy folders under \`skills/\` into \`.cursor/skills/\` in this project.
+
+### Claude Code (Plugin marketplace)
+- Add marketplace: \`/plugin marketplace add mikonos/zettelkasten-agent-skills\`
+- Install plugin: \`/plugin install zettelkasten-agent-skills@mikonos-zettelkasten\`
+
+## How to work
+When I give you raw text (meeting notes, article highlights, or a draft note), do:
+1) Extract 3-7 atomic notes (each with a clear title + 3-10 lines body).
+2) For each note: propose 2+ backlinks I should create (with why).
+3) Suggest 3-7 searchable keywords to help future retrieval.
+4) If you need assumptions, write them explicitly as "Assumptions:".
+`,
+    author: {
+      name: "mikonos",
+      url: "https://github.com/mikonos",
+      avatar: "https://github.com/mikonos.png",
+    },
+  },
+];
+


### PR DESCRIPTION
Add a Productivity/Zettelkasten rule that points users to the zettelkasten-agent-skills pack and includes Cursor + Claude Code installation instructions.