### PR TITLE
Add FormBack MCP server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "FormBack",
+    url: "https://github.com/otopba/formback/tree/main/mcp",
+    description:
+      "MCP server for FormBack — the form backend API for static sites. Manage forms, view submissions, and check account stats directly from AI assistants like Claude and Cursor.",
+    logo: "https://formback.email/favicon.svg",
+  },
 ];


### PR DESCRIPTION
Adds [FormBack](https://formback.email) MCP server to the directory.

FormBack is a form backend API for static sites. The MCP server (available on npm as `formback-mcp`) provides 8 tools for managing forms and submissions directly from AI assistants like Claude Desktop and Cursor.

- **npm:** https://www.npmjs.com/package/formback-mcp
- **GitHub:** https://github.com/otopba/formback/tree/main/mcp
- **Website:** https://formback.email