### PR TITLE
Add Money — personal finance MCP server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "Money",
+    url: "https://github.com/Parsons-ai/money-mcp-server",
+    description:
+      "Personal finance assistant — track transactions, budgets, net worth, and subscriptions via Plaid-connected bank data. Query your finances with natural language.",
+    logo: "https://money.parsons.ai/favicon.ico",
+  },
 ];


### PR DESCRIPTION
## Summary
- Adds **Money** by [Parsons.AI](https://parsons.ai) to the MCP server directory
- Personal finance assistant that connects to bank accounts via Plaid
- Query transactions, create budgets, track subscriptions, and monitor net worth using natural language
- OAuth 2.1 authenticated, remote streamable HTTP transport

## Server Details
- **URL:** https://money.parsons.ai/api/mcp
- **GitHub:** https://github.com/Parsons-ai/money-mcp-server
- **Transport:** Streamable HTTP
- **Auth:** OAuth 2.1 with Dynamic Client Registration
- **Tools:** whoami, schema, query, mutate, sync