### PR TITLE
Add AgentPMT MCP server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -7,6 +7,12 @@ export type MCP = {
 
 export default [
   {
+    name: "AgentPMT",
+    url: "https://github.com/Apoth3osis-ai/agentpmt-mcp-public",
+    description:
+      "AI agent marketplace for automated employees, workflows, skills, and tool orchestration via a single MCP connection.",
+  },
+  {
     name: "Upstash",
     url: "https://github.com/upstash/mcp-server",
     description:


### PR DESCRIPTION
## Summary

- Adds AgentPMT to the MCP servers directory
- AgentPMT is an AI agent marketplace for automated employees, workflows, skills, and tool orchestration via a single MCP connection
- GitHub: https://github.com/Apoth3osis-ai/agentpmt-mcp-public

## Changes

- Added AgentPMT entry to `packages/data/src/mcp/index.ts` in alphabetical order
- Follows the existing entry format (name, url, description)
