### PR TITLE
Add CryptoMinute MCP server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,10 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "CryptoMinute",
+    url: "https://github.com/zkoranges/crypto_minute/tree/main/cmd/mcp",
+    description:
+      "AI-powered crypto news intelligence MCP server with 8 tools: news search, narrative analytics, AI-clustered stories, Reddit sentiment, YouTube engagement, historical prices, token metadata, and Telegram flash posts.",
+  },
 ];


### PR DESCRIPTION
## Summary

Adds [CryptoMinute](https://github.com/zkoranges/crypto_minute/tree/main/cmd/mcp) to the MCP server directory.

CryptoMinute is an AI-powered crypto news intelligence MCP server that provides 8 tools:

- **News Search** - Search crypto news articles with keyword and date filtering
- **Narrative Analytics** - AI-generated narrative analysis of crypto market themes
- **AI-Clustered Stories** - Automatically clustered and summarized news stories
- **Reddit Sentiment** - Monitor crypto sentiment across Reddit communities
- **YouTube Engagement** - Track crypto-related YouTube content and engagement
- **Historical Prices** - Retrieve historical cryptocurrency price data
- **Token Metadata** - Look up metadata for crypto tokens
- **Telegram Flash Posts** - Real-time flash news posts from Telegram channels

The server is built in Go and supports both stdio and SSE transports, compatible with Cursor, Claude Desktop, and other MCP clients.

## Test plan

- [x] Entry follows the existing `MCP` type format in `packages/data/src/mcp/index.ts`
- [ ] Verify the entry renders correctly on the directory site