### PR TITLE
Add EVC Team Relay MCP server (Obsidian vault access)

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "EVC Team Relay MCP",
+    url: "https://github.com/entire-vc/evc-team-relay-mcp",
+    description:
+      "Read, search, and write Obsidian vault notes via Team Relay collaborative server. Supports shared folders, real-time sync, and AI agent access.",
+    logo: "https://avatars.githubusercontent.com/u/73277481?v=4",
+  },
 ];


### PR DESCRIPTION
## Description

Adds [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp) to the MCP directory.

**evc-team-relay-mcp** is a Python MCP server that enables AI agents to read, search, and write Obsidian vault notes via a Team Relay collaborative server. It supports shared folders, real-time sync, and AI agent access.

### Installation
```
uvx evc-team-relay-mcp
```

### PyPI
https://pypi.org/project/evc-team-relay-mcp/

### Author
Entire VC
