### PR TITLE
feat: add idea-reality-mcp — pre-build reality check for AI coding agents

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "idea-reality-mcp",
+    url: "https://github.com/mnemox-ai/idea-reality-mcp",
+    description:
+      "Pre-build reality check for AI coding agents. Scans GitHub, Hacker News, npm, PyPI & Product Hunt in parallel before your AI starts coding. Returns a 0-100 reality signal, similar projects, duplicate likelihood, and pivot suggestions.",
+    logo: "https://avatars.githubusercontent.com/u/263367191?v=4",
+  },
 ];


### PR DESCRIPTION
## Description

Adds [idea-reality-mcp](https://github.com/mnemox-ai/idea-reality-mcp) to the MCP server list.

## What it does

Pre-build reality check for AI coding agents. Before your AI starts coding, it scans GitHub, Hacker News, npm, PyPI & Product Hunt in parallel and returns:
- Reality signal (0-100)
- Duplicate likelihood (low/medium/high)
- Top similar projects with links
- Actionable pivot suggestions

## Install

```json
{
  "mcpServers": {
    "idea-reality": {
      "command": "uvx",
      "args": ["idea-reality-mcp"]
    }
  }
}
```

## Stats
- 105+ GitHub stars
- 500+ PyPI downloads
- MIT license, Python 3.11+
- Live demo: https://mnemox.ai/check