### PR TITLE
Add NotebookLM MCP server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "NotebookLM",
+    url: "https://github.com/roomi-fields/notebooklm-mcp",
+    description:
+      "Full automation of Google NotebookLM — Q&A with citations, audio podcasts, video summaries, content generation, source management, and notebook library.",
+    logo: "https://www.gstatic.com/lamda/images/gemini_sparkle_v002_d4735304ff6292a690b6.svg",
+  },
 ];


### PR DESCRIPTION
## Summary

Adds the **NotebookLM MCP server** to the MCP directory.

- **Name**: NotebookLM
- **Repo**: https://github.com/roomi-fields/notebooklm-mcp
- **npm**: [@roomi-fields/notebooklm-mcp](https://www.npmjs.com/package/@roomi-fields/notebooklm-mcp)

Full automation of Google NotebookLM via MCP + HTTP REST API:
- Q&A with citation extraction (source names + excerpts)
- Audio podcast generation & download
- Video summaries, presentations, reports, infographics, data tables
- Source/document management (file, URL, text, YouTube, Google Drive)
- Notebook library with search & metadata

## Changes

Single addition to `packages/data/src/mcp/index.ts` — one new MCP entry object.