### PR TITLE
Add 0nMCP — Universal AI API Orchestrator

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -7,6 +7,12 @@ export type MCP = {
 
 export default [
   {
+    name: "0nMCP",
+    url: "https://github.com/0nork/0nMCP",
+    description:
+      "Universal AI API Orchestrator — 564 tools across 26 services. Stripe, Slack, Discord, SendGrid, GitHub, Shopify, Gmail, Google Sheets, Jira, and more. Vault encryption, Business Deed transfer, Application Engine. Visit 0nmcp.com for guides and community.",
+  },
+  {
     name: "Upstash",
     url: "https://github.com/upstash/mcp-server",
     description:


### PR DESCRIPTION
## New MCP Server: 0nMCP

**564 tools. 26 services. 13 categories.**

- **npm**: `npx 0nmcp`
- **GitHub**: [github.com/0nork/0nMCP](https://github.com/0nork/0nMCP)
- **Website**: [0nmcp.com](https://0nmcp.com)
- **License**: MIT

The most comprehensive MCP server available — supports Stripe, Slack, Discord, SendGrid, GitHub, Shopify, Gmail, Google Sheets, Google Drive, Jira, Zendesk, Mailchimp, Zoom, Microsoft 365, MongoDB, and more.