### PR TITLE
Add Xquik MCP server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "Xquik",
+    url: "https://github.com/Xquik-dev/x-twitter-scraper",
+    description:
+      "Real-time X (Twitter) data platform with 22 MCP tools. Search tweets, monitor accounts, extract followers, run giveaway draws, look up profiles, check follow relationships, and access trending topics.",
+    logo: "https://avatars.githubusercontent.com/u/263527900?v=4",
+  },
 ];


### PR DESCRIPTION
## Summary

Adds [Xquik](https://xquik.com) to the MCP server directory. Xquik is a real-time X (Twitter) data platform that exposes 22 MCP tools:

- **Search & lookup**: search tweets, look up individual tweets, get user profiles, check follow relationships
- **Monitoring**: watch accounts for new tweets, replies, retweets, quote tweets, and follower changes
- **Extraction**: 19 bulk extraction tools (followers, following, replies, reposts, quotes, threads, mentions, community members, list members, and more)
- **Giveaways**: run raffle draws from tweet replies with configurable filters
- **Trends**: get trending topics by region

**Transport**: StreamableHTTP  
**Auth**: API key (`x-api-key` header)  
**GitHub**: https://github.com/Xquik-dev/x-twitter-scraper  
**Website**: https://xquik.com