### PR TITLE
Add Screaming Frog SEO Spider MCP server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,10 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "Screaming Frog SEO Spider",
+    url: "https://github.com/bzsasson/screaming-frog-mcp",
+    description:
+      "Crawl websites, export SEO data, and manage crawls via Screaming Frog SEO Spider. Install with uvx screaming-frog-mcp or pip install screaming-frog-mcp.",
+  },
 ];


### PR DESCRIPTION
## Summary

- Adds the **Screaming Frog SEO Spider MCP server** to the MCP directory listing
- This server enables AI assistants to crawl websites, export SEO data, and manage crawls via Screaming Frog SEO Spider
- Available on PyPI as `screaming-frog-mcp` (install via `uvx screaming-frog-mcp` or `pip install screaming-frog-mcp`)
- Repository: https://github.com/bzsasson/screaming-frog-mcp
- Category: SEO / Marketing
- Transport: stdio