### PR TITLE
feat: add AI Site Scorer MCP server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "AI Site Scorer",
+    url: "https://github.com/MinglesAI/ai-site-scorer",
+    description:
+      "Analyze any website for AI/LLM readiness directly from Cursor or Claude Desktop. Runs 18 automated checks (Schema.org, llms.txt, robots.txt, E-E-A-T, Open Graph) and returns per-platform scores for ChatGPT, Perplexity, Claude, and Gemini — plus IDE-ready fix prompts.",
+    logo: "https://ai-readiness.mingles.ai/og-image.png",
+  },
 ];


### PR DESCRIPTION
## AI Site Scorer MCP Server

Adds **[AI Site Scorer](https://github.com/MinglesAI/ai-site-scorer)** — an MCP server that analyzes websites for AI/LLM readiness directly from Cursor, Claude Desktop, or VS Code.

### What it does
- Runs 18 automated checks: Schema.org/JSON-LD, llms.txt, robots.txt AI directives, E-E-A-T signals, Open Graph, canonical URL, content depth, citation readiness
- Returns separate scores for ChatGPT, Perplexity, Claude, and Gemini
- Provides IDE-ready fix prompts (paste directly into Cursor agent mode)

### Usage in Cursor
```json
{
  "mcpServers": {
    "ai-site-scorer": {
      "url": "https://ai-readiness.mingles.ai/api/mcp/",
      "headers": { "Authorization": "Bearer sk_live_YOUR_KEY" }
    }
  }
}
```

Free tier: 100 analyses/month | Repo: https://github.com/MinglesAI/ai-site-scorer