### PR TITLE
Add mac-use-mcp — macOS desktop automation

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "mac-use-mcp",
+    url: "https://github.com/antbotlab/mac-use-mcp",
+    description:
+      "Zero-dependency macOS desktop automation for AI agents. Screenshot, mouse, keyboard, clipboard, window management, and accessibility inspection via 18 MCP tools. One command install: npx mac-use-mcp.",
+    logo: "https://avatars.githubusercontent.com/u/206038612?s=200&v=4",
+  },
 ];


### PR DESCRIPTION
Adds [mac-use-mcp](https://github.com/antbotlab/mac-use-mcp) to the MCP server directory.

**mac-use-mcp** — Zero-dependency macOS desktop automation for AI agents.

- One command install: `npx mac-use-mcp`
- 18 tools: screenshot, click, type, scroll, drag, window management, menu bar, accessibility inspection, clipboard
- macOS 13+ (Ventura through Sequoia), Intel & Apple Silicon
- Zero native dependencies — no Xcode, no node-gyp, no Python
- Works with Claude Code, Claude Desktop, Cursor, Windsurf, and any MCP client
- MIT licensed, published on npm