### PR TITLE
Add GrantAi MCP server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "GrantAi",
+    url: "https://github.com/solonai-com/grantai",
+    description:
+      "Persistent memory for AI agents. Provides infinite context with sub-millisecond recall. Local-first, AES-256 encrypted, works across Claude Code, Cursor, Windsurf, and any MCP client.",
+    logo: "https://raw.githubusercontent.com/solonai-com/grantai/main/assets/logo-400x400.png",
+  },
 ];


### PR DESCRIPTION
## Summary

Adding **GrantAi** - persistent memory for AI agents.

## Server Details

- **Name**: GrantAi
- **Repository**: https://github.com/solonai-com/grantai
- **Website**: https://solonai.com/grantai
- **Official MCP Registry**: `com.solonai/grantai`

## Features

- Infinite context with sub-millisecond recall
- Local-first architecture (all data stays on device)
- AES-256 encrypted storage
- Works with Claude Code, Cursor, Windsurf, and any MCP client
- Native packages for macOS and Linux, plus Docker

## Logo

400x400 PNG included: https://raw.githubusercontent.com/solonai-com/grantai/main/assets/logo-400x400.png