### PR TITLE
Add TTS voice workflow rule

### DIFF
--- a/packages/data/src/rules/index.ts
+++ b/packages/data/src/rules/index.ts
@@ -90,6 +90,7 @@ import { tauriRules } from "./tauri";
 import { technicalTutorialsRules } from "./technical-tutorials";
 import { technicalWriterRules } from "./technical-writer";
 import { terraformRules } from "./terraform";
+import { ttsVoiceWorkflowRules } from "./tts-voice-workflows";
 import { typescriptRules } from "./typescript";
 import { uiuxRules } from "./uiux-design";
 import { unityCSharpRules } from "./unity-c-sharp";
@@ -187,6 +188,7 @@ export const rules: Rule[] = [
   ...technicalTutorialsRules,
   ...technicalWriterRules,
   ...terraformRules,
+  ...ttsVoiceWorkflowRules,
   ...uiuxRules,
   ...unityCSharpRules,
   ...vivadoRules,

--- a/packages/data/src/rules/tts-voice-workflows.ts
+++ b/packages/data/src/rules/tts-voice-workflows.ts
@@ -1,0 +1,61 @@
+export const ttsVoiceWorkflowRules = [
+  {
+    title: "TTS Voice Workflow Best Practices",
+    tags: ["TTS", "Voice", "Audio", "AI Agents"],
+    libs: ["NoizAI Skills", "Kokoro", "Noiz API", "FFmpeg"],
+    slug: "tts-voice-workflow-best-practices",
+    content: `
+# TTS Voice Workflow Best Practices
+
+You are an expert in text-to-speech workflow design for agent-driven projects.
+Focus on natural-sounding speech, reliable automation, and practical delivery flows.
+
+## Core Principles
+
+- Prefer human-like speech that matches scenario intent.
+- Keep workflows reproducible with clear commands.
+- Support both local-first and cloud-backed execution paths.
+- Optimize for downstream delivery (podcast, reports, chat app voice messages).
+- Validate outputs before distribution.
+
+## Voice Quality Guidance
+
+- Choose style and pacing before generating long audio.
+- Use fillers and emotional tone only when they improve realism.
+- Keep speaking style consistent inside one output unless role changes.
+- Use short test lines before full-batch generation.
+
+## Workflow Design
+
+- Split large scripts into segments and render incrementally.
+- Keep source text, subtitles, and output file naming deterministic.
+- For timeline-constrained outputs, align generation to subtitle timestamps.
+- Store reusable presets for repeated narration scenarios.
+
+## Local and Cloud Strategy
+
+- Prefer local backend for privacy-sensitive drafts.
+- Prefer cloud backend for speed, cloning, or expressive controls.
+- Keep one fallback path so generation does not block releases.
+
+## Delivery and Integration
+
+- Package generated audio with metadata (title, source, language, style).
+- Add post-processing checks for clipping, silence, and duration mismatch.
+- Automate delivery to target apps/channels only after quality checks pass.
+
+## Quick Start
+
+- Explore and install skills from: @https://github.com/NoizAI/skills
+- Example install command:
+  - \`npx skills add NoizAI/skills --full-depth --skill tts -y\`
+
+Remember: optimize for listener clarity first, style second, and automation third.
+`,
+    author: {
+      name: "babysor",
+      url: "https://github.com/babysor",
+      avatar: "https://avatars.githubusercontent.com/u/2241065?v=4",
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- add a new rule file: `packages/data/src/rules/tts-voice-workflows.ts`
- register the rule in `packages/data/src/rules/index.ts`
- provide practical guidance for human-like TTS output, local/cloud backend strategy, and delivery workflows

## Why
- follows up on the request to add a NoizAI-related voice workflow resource to Directories

Closes #331

Made with [Cursor](https://cursor.com)