### PR TITLE
Add SeedFlip MCP server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "SeedFlip",
+    url: "https://github.com/bockenstette1/seedflip",
+    description:
+      "100+ curated design systems for AI coding agents. Give your agent design taste instead of guessing colors and fonts. Returns production-ready tokens in Tailwind, CSS, shadcn/ui, or raw format.",
+    logo: "https://seedflip.co/flip-white.png",
+  },
 ];


### PR DESCRIPTION
## What

Adds [SeedFlip](https://seedflip.co) to the MCP server directory.

## What it does

SeedFlip gives AI coding agents access to 100+ curated design systems. Instead of guessing colors and fonts, agents call `get_design_seed` with a reference like "Stripe" or "dark minimal" and get production-ready design tokens back in Tailwind, CSS, shadcn/ui, or raw token format.

- **npm:** [seedflip-mcp](https://www.npmjs.com/package/seedflip-mcp)
- **Install:** `npx -y seedflip-mcp`
- **No API keys required**
- **MCP Registry:** Already published to the official MCP Registry as `io.github.bockenstette1/seedflip`