### PR TITLE
feat: add Phantom MCP Server

### DIFF
--- a/packages/data/src/mcp/index.ts
+++ b/packages/data/src/mcp/index.ts
@@ -247,4 +247,11 @@ export default [
       "Leverage SettleMint's Model Context Protocol server to seamlessly interact with enterprise blockchain infrastructure. Build, deploy, and manage smart contracts through AI-powered assistants, streamlining your blockchain development workflow for maximum efficiency.",
     logo: "https://console.settlemint.com/android-chrome-512x512.png",
   },
+  {
+    name: "Phantom",
+    url: "https://github.com/phantom/phantom-connect-cursor-plugin",
+    description:
+      "Give your AI agent a crypto wallet. Sign messages, send transactions, transfer tokens, and swap across Solana and EVM chains using Phantom's non-custodial wallet. Built by the Phantom team.",
+    logo: "https://raw.githubusercontent.com/phantom/phantom-connect-cursor-plugin/main/assets/avatar.svg",
+  },
 ];


### PR DESCRIPTION
## Summary

Adds the official **Phantom MCP Server** to the directory.

**Package:** `@phantom/mcp-server`
**Repo:** https://github.com/phantom/phantom-connect-cursor-plugin
**Docs:** https://docs.phantom.com/mcp

Phantom MCP Server gives AI agents a crypto wallet — sign messages, send transactions, transfer tokens, and swap across Solana and EVM chains using Phantom's non-custodial wallet. Built and maintained by the Phantom team.

### Config

```json
{
  "mcpServers": {
    "phantom": {
      "command": "npx",
      "args": ["-y", "@phantom/mcp-server"],
      "env": {
        "PHANTOM_APP_ID": "your-phantom-app-id"
      }
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)