### PR TITLE
Clean up next-safe-action and zod deprecations

### DIFF
--- a/apps/cursor/src/actions/create-job-listing.ts
+++ b/apps/cursor/src/actions/create-job-listing.ts
@@ -16,7 +16,7 @@ export const createJobListingAction = authActionClient
       company_id: z.string(),
       location: z.string().nullable(),
       description: z.string(),
-      link: z.string().url(),
+      link: z.url(),
       workplace: z.enum(["On site", "Remote", "Hybrid"]),
       experience: z.string().nullable(),
     }),

--- a/apps/cursor/src/actions/create-job-listing.ts
+++ b/apps/cursor/src/actions/create-job-listing.ts
@@ -10,7 +10,7 @@ export const createJobListingAction = authActionClient
   .metadata({
     actionName: "create-job-listing",
   })
-  .schema(
+  .inputSchema(
     z.object({
       title: z.string(),
       company_id: z.string(),

--- a/apps/cursor/src/actions/create-plugin.ts
+++ b/apps/cursor/src/actions/create-plugin.ts
@@ -29,13 +29,17 @@ export const createPluginAction = authActionClient
   })
   .inputSchema(
     z.object({
-      name: z.string().min(2, "Name must be at least 2 characters"),
-      description: z.string().min(10, "Description must be at least 10 characters"),
+      name: z.string().min(2, { error: "Name must be at least 2 characters" }),
+      description: z
+        .string()
+        .min(10, { error: "Description must be at least 10 characters" }),
       logo: z.string().nullable().optional(),
-      repository: z.string().url().nullable().optional(),
-      homepage: z.string().url().nullable().optional(),
+      repository: z.url().nullable().optional(),
+      homepage: z.url().nullable().optional(),
       keywords: z.array(z.string()).optional(),
-      components: z.array(componentSchema).min(1, "At least one component is required"),
+      components: z
+        .array(componentSchema)
+        .min(1, { error: "At least one component is required" }),
     }),
   )
   .action(

--- a/apps/cursor/src/actions/create-plugin.ts
+++ b/apps/cursor/src/actions/create-plugin.ts
@@ -27,7 +27,7 @@ export const createPluginAction = authActionClient
   .metadata({
     actionName: "create-plugin",
   })
-  .schema(
+  .inputSchema(
     z.object({
       name: z.string().min(2, "Name must be at least 2 characters"),
       description: z.string().min(10, "Description must be at least 10 characters"),

--- a/apps/cursor/src/actions/create-post-action.ts
+++ b/apps/cursor/src/actions/create-post-action.ts
@@ -13,7 +13,7 @@ export const createPostAction = authActionClient
     z.object({
       title: z.string(),
       content: z.string().optional().nullable(),
-      url: z.string().url().nullable(),
+      url: z.url().nullable(),
     }),
   )
   .action(async ({ parsedInput: { title, content, url }, ctx: { userId } }) => {

--- a/apps/cursor/src/actions/create-post-action.ts
+++ b/apps/cursor/src/actions/create-post-action.ts
@@ -9,7 +9,7 @@ export const createPostAction = authActionClient
   .metadata({
     actionName: "create-post",
   })
-  .schema(
+  .inputSchema(
     z.object({
       title: z.string(),
       content: z.string().optional().nullable(),

--- a/apps/cursor/src/actions/delete-post-action.ts
+++ b/apps/cursor/src/actions/delete-post-action.ts
@@ -7,7 +7,7 @@ export const deletePostAction = authActionClient
   .metadata({
     actionName: "delete-post",
   })
-  .schema(
+  .inputSchema(
     z.object({
       postId: z.number(),
     }),

--- a/apps/cursor/src/actions/edit-profile.ts
+++ b/apps/cursor/src/actions/edit-profile.ts
@@ -9,7 +9,7 @@ export const editProfileAction = authActionClient
   .metadata({
     actionName: "edit-profile",
   })
-  .schema(
+  .inputSchema(
     z.object({
       name: z.string(),
       slug: z.string().nullable(),

--- a/apps/cursor/src/actions/parse-github-plugin.ts
+++ b/apps/cursor/src/actions/parse-github-plugin.ts
@@ -158,7 +158,7 @@ export const parseGitHubPluginAction = authActionClient
   .metadata({ actionName: "parse-github-plugin" })
   .inputSchema(
     z.object({
-      url: z.string().url("Please enter a valid GitHub URL"),
+      url: z.url({ error: "Please enter a valid GitHub URL" }),
     }),
   )
   .action(async ({ parsedInput: { url } }) => {

--- a/apps/cursor/src/actions/parse-github-plugin.ts
+++ b/apps/cursor/src/actions/parse-github-plugin.ts
@@ -156,7 +156,7 @@ async function fetchGitHubTree(
 
 export const parseGitHubPluginAction = authActionClient
   .metadata({ actionName: "parse-github-plugin" })
-  .schema(
+  .inputSchema(
     z.object({
       url: z.string().url("Please enter a valid GitHub URL"),
     }),

--- a/apps/cursor/src/actions/review-plugin.ts
+++ b/apps/cursor/src/actions/review-plugin.ts
@@ -10,7 +10,7 @@ import { ActionError, adminActionClient } from "./safe-action";
 
 export const approvePluginAction = adminActionClient
   .metadata({ actionName: "approve-plugin" })
-  .schema(z.object({ pluginId: z.string().uuid() }))
+  .inputSchema(z.object({ pluginId: z.string().uuid() }))
   .action(async ({ parsedInput: { pluginId } }) => {
     const supabase = await createClient();
 
@@ -60,7 +60,7 @@ export const approvePluginAction = adminActionClient
 
 export const declinePluginAction = adminActionClient
   .metadata({ actionName: "decline-plugin" })
-  .schema(z.object({ pluginId: z.string().uuid() }))
+  .inputSchema(z.object({ pluginId: z.string().uuid() }))
   .action(async ({ parsedInput: { pluginId } }) => {
     const supabase = await createClient();
 

--- a/apps/cursor/src/actions/review-plugin.ts
+++ b/apps/cursor/src/actions/review-plugin.ts
@@ -10,7 +10,7 @@ import { ActionError, adminActionClient } from "./safe-action";
 
 export const approvePluginAction = adminActionClient
   .metadata({ actionName: "approve-plugin" })
-  .inputSchema(z.object({ pluginId: z.string().uuid() }))
+  .inputSchema(z.object({ pluginId: z.uuid() }))
   .action(async ({ parsedInput: { pluginId } }) => {
     const supabase = await createClient();
 
@@ -60,7 +60,7 @@ export const approvePluginAction = adminActionClient
 
 export const declinePluginAction = adminActionClient
   .metadata({ actionName: "decline-plugin" })
-  .inputSchema(z.object({ pluginId: z.string().uuid() }))
+  .inputSchema(z.object({ pluginId: z.uuid() }))
   .action(async ({ parsedInput: { pluginId } }) => {
     const supabase = await createClient();
 

--- a/apps/cursor/src/actions/star-plugin.ts
+++ b/apps/cursor/src/actions/star-plugin.ts
@@ -10,7 +10,7 @@ export const starPluginAction = authActionClient
   .metadata({
     actionName: "star-plugin",
   })
-  .schema(
+  .inputSchema(
     z.object({
       pluginId: z.string().uuid(),
       slug: z.string(),

--- a/apps/cursor/src/actions/star-plugin.ts
+++ b/apps/cursor/src/actions/star-plugin.ts
@@ -12,7 +12,7 @@ export const starPluginAction = authActionClient
   })
   .inputSchema(
     z.object({
-      pluginId: z.string().uuid(),
+      pluginId: z.uuid(),
       slug: z.string(),
     }),
   )

--- a/apps/cursor/src/actions/toggle-follow-action.ts
+++ b/apps/cursor/src/actions/toggle-follow-action.ts
@@ -13,7 +13,7 @@ export const toggleFollowAction = authActionClient
   .metadata({
     actionName: "toggle-follow",
   })
-  .schema(
+  .inputSchema(
     z.object({
       action: z.enum(["follow", "unfollow"]),
       userId: z.string().uuid(),

--- a/apps/cursor/src/actions/toggle-follow-action.ts
+++ b/apps/cursor/src/actions/toggle-follow-action.ts
@@ -16,7 +16,7 @@ export const toggleFollowAction = authActionClient
   .inputSchema(
     z.object({
       action: z.enum(["follow", "unfollow"]),
-      userId: z.string().uuid(),
+      userId: z.uuid(),
       slug: z.string(),
     }),
   )

--- a/apps/cursor/src/actions/toggle-job-listing.ts
+++ b/apps/cursor/src/actions/toggle-job-listing.ts
@@ -9,7 +9,7 @@ export const toggleJobListingAction = authActionClient
   .metadata({
     actionName: "toggle-job-listing",
   })
-  .schema(
+  .inputSchema(
     z.object({
       id: z.number(),
       active: z.boolean(),

--- a/apps/cursor/src/actions/toggle-mcp-listing.ts
+++ b/apps/cursor/src/actions/toggle-mcp-listing.ts
@@ -9,7 +9,7 @@ export const toggleMCPListingAction = authActionClient
   .metadata({
     actionName: "toggle-mcp-listing",
   })
-  .schema(
+  .inputSchema(
     z.object({
       id: z.string(),
       active: z.boolean(),

--- a/apps/cursor/src/actions/update-job-listing.ts
+++ b/apps/cursor/src/actions/update-job-listing.ts
@@ -16,7 +16,7 @@ export const updateJobListingAction = authActionClient
       company_id: z.string(),
       location: z.string().nullable(),
       description: z.string(),
-      link: z.string().url(),
+      link: z.url(),
       workplace: z.enum(["On site", "Remote", "Hybrid"]),
       experience: z.string().nullable(),
     }),

--- a/apps/cursor/src/actions/update-job-listing.ts
+++ b/apps/cursor/src/actions/update-job-listing.ts
@@ -9,7 +9,7 @@ export const updateJobListingAction = authActionClient
   .metadata({
     actionName: "update-job-listing",
   })
-  .schema(
+  .inputSchema(
     z.object({
       id: z.number(),
       title: z.string(),

--- a/apps/cursor/src/actions/update-mcp-listing.tsx
+++ b/apps/cursor/src/actions/update-mcp-listing.tsx
@@ -16,7 +16,7 @@ export const updateMCPListingAction = authActionClient
       company_id: z.string().optional(),
       description: z.string(),
       config: z.record(z.string(), z.any()).nullable(),
-      link: z.string().url(),
+      link: z.url(),
       logo: z.string().optional(),
     }),
   )

--- a/apps/cursor/src/actions/update-mcp-listing.tsx
+++ b/apps/cursor/src/actions/update-mcp-listing.tsx
@@ -9,7 +9,7 @@ export const updateMCPListingAction = authActionClient
   .metadata({
     actionName: "update-mcp-listing",
   })
-  .schema(
+  .inputSchema(
     z.object({
       id: z.string(),
       name: z.string(),

--- a/apps/cursor/src/actions/update-plugin.ts
+++ b/apps/cursor/src/actions/update-plugin.ts
@@ -28,18 +28,18 @@ export const updatePluginAction = authActionClient
   })
   .inputSchema(
     z.object({
-      id: z.string().uuid(),
-      name: z.string().min(2, "Name must be at least 2 characters"),
+      id: z.uuid(),
+      name: z.string().min(2, { error: "Name must be at least 2 characters" }),
       description: z
         .string()
-        .min(10, "Description must be at least 10 characters"),
+        .min(10, { error: "Description must be at least 10 characters" }),
       logo: z.string().nullable().optional(),
-      repository: z.string().url().nullable().optional(),
-      homepage: z.string().url().nullable().optional(),
+      repository: z.url().nullable().optional(),
+      homepage: z.url().nullable().optional(),
       keywords: z.array(z.string()).optional(),
       components: z
         .array(componentSchema)
-        .min(1, "At least one component is required"),
+        .min(1, { error: "At least one component is required" }),
     }),
   )
   .action(

--- a/apps/cursor/src/actions/update-plugin.ts
+++ b/apps/cursor/src/actions/update-plugin.ts
@@ -26,7 +26,7 @@ export const updatePluginAction = authActionClient
   .metadata({
     actionName: "update-plugin",
   })
-  .schema(
+  .inputSchema(
     z.object({
       id: z.string().uuid(),
       name: z.string().min(2, "Name must be at least 2 characters"),

--- a/apps/cursor/src/actions/update-settings.ts
+++ b/apps/cursor/src/actions/update-settings.ts
@@ -9,7 +9,7 @@ export const updateSettingsAction = authActionClient
   .metadata({
     actionName: "update-settings",
   })
-  .schema(
+  .inputSchema(
     z.object({
       follow_email: z.boolean(),
     }),

--- a/apps/cursor/src/actions/upsert-company.ts
+++ b/apps/cursor/src/actions/upsert-company.ts
@@ -13,7 +13,7 @@ export const upsertCompanyAction = authActionClient
     z.object({
       id: z.string().optional(),
       name: z.string(),
-      image: z.string().url().nullable(),
+      image: z.url().nullable(),
       slug: z.string().optional(),
       location: z.string().nullable(),
       bio: z.string().nullable(),

--- a/apps/cursor/src/actions/upsert-company.ts
+++ b/apps/cursor/src/actions/upsert-company.ts
@@ -9,7 +9,7 @@ export const upsertCompanyAction = authActionClient
   .metadata({
     actionName: "upsert-company",
   })
-  .schema(
+  .inputSchema(
     z.object({
       id: z.string().optional(),
       name: z.string(),

--- a/apps/cursor/src/actions/vote-post-action.ts
+++ b/apps/cursor/src/actions/vote-post-action.ts
@@ -9,7 +9,7 @@ export const votePostAction = authActionClient
   .metadata({
     actionName: "vote-post",
   })
-  .schema(
+  .inputSchema(
     z.object({
       postId: z.number(),
       action: z.enum(["upvote", "downvote"]),

--- a/apps/cursor/src/components/forms/company.tsx
+++ b/apps/cursor/src/components/forms/company.tsx
@@ -26,33 +26,33 @@ const formSchema = z.object({
   name: z
     .string()
     .min(2, {
-      message: "Name must be at least 2 characters.",
+      error: "Name must be at least 2 characters.",
     })
     .max(50, {
-      message: "Name must be less than 50 characters.",
+      error: "Name must be less than 50 characters.",
     }),
   location: z
     .string()
     .max(100, {
-      message: "Location must be less than 100 characters.",
+      error: "Location must be less than 100 characters.",
     })
     .optional(),
   bio: z
     .string()
     .max(500, {
-      message: "Bio must be less than 500 characters.",
+      error: "Bio must be less than 500 characters.",
     })
     .optional(),
   website: z
     .string()
-    .url({ message: "Please enter a valid website URL." })
+    .url({ error: "Please enter a valid website URL." })
     .or(z.literal("")),
   social_x_link: z
     .string()
-    .url({ message: "Please enter a valid X URL." })
+    .url({ error: "Please enter a valid X URL." })
     .or(z.literal("")),
   is_public: z.boolean().optional(),
-  image: z.string().url().nullable(),
+  image: z.url().nullable(),
 });
 
 type CompanyData = {

--- a/apps/cursor/src/components/forms/edit-job.tsx
+++ b/apps/cursor/src/components/forms/edit-job.tsx
@@ -44,8 +44,8 @@ const formSchema = z.object({
     .max(500, {
       message: "Description must be less than 500 characters.",
     }),
-  link: z.string().url({
-    message: "Please enter a valid job posting URL.",
+  link: z.url({
+    error: "Please enter a valid job posting URL.",
   }),
   workplace: z.enum(["On site", "Remote", "Hybrid"]),
   experience: z.string().optional(),

--- a/apps/cursor/src/components/forms/edit-mcp.tsx
+++ b/apps/cursor/src/components/forms/edit-mcp.tsx
@@ -32,8 +32,8 @@ const formSchema = z.object({
     .max(500, {
       message: "Description must be less than 500 characters.",
     }),
-  link: z.string().url({
-    message: "Please enter a valid job posting URL.",
+  link: z.url({
+    error: "Please enter a valid job posting URL.",
   }),
   logo: z.string().optional(),
   company_id: z.string().optional(),

--- a/apps/cursor/src/components/forms/job.tsx
+++ b/apps/cursor/src/components/forms/job.tsx
@@ -43,8 +43,8 @@ const formSchema = z.object({
     .max(500, {
       message: "Description must be less than 500 characters.",
     }),
-  link: z.string().url({
-    message: "Please enter a valid job posting URL.",
+  link: z.url({
+    error: "Please enter a valid job posting URL.",
   }),
   workplace: z.enum(["On site", "Remote", "Hybrid"]),
   experience: z.string().optional(),

--- a/apps/cursor/src/components/forms/plugin-form.tsx
+++ b/apps/cursor/src/components/forms/plugin-form.tsx
@@ -97,9 +97,8 @@ function slugify(value: string) {
 
 const autoFormSchema = z.object({
   url: z
-    .string()
-    .url("Please enter a valid URL")
-    .regex(/github\.com/, "Must be a GitHub URL"),
+    .url({ error: "Please enter a valid URL" })
+    .regex(/github\.com/, { error: "Must be a GitHub URL" }),
 });
 
 export function PluginForm() {

--- a/apps/cursor/src/components/forms/post.tsx
+++ b/apps/cursor/src/components/forms/post.tsx
@@ -32,7 +32,7 @@ const formSchema = z.object({
       message: "Content must be less than 500 characters.",
     })
     .optional(),
-  url: z.string().url(),
+  url: z.url(),
 });
 
 export function PostForm({ onSuccess }: { onSuccess: () => void }) {

--- a/apps/cursor/src/components/forms/profile.tsx
+++ b/apps/cursor/src/components/forms/profile.tsx
@@ -23,41 +23,41 @@ const formSchema = z.object({
   name: z
     .string()
     .min(2, {
-      message: "Name must be at least 2 characters.",
+      error: "Name must be at least 2 characters.",
     })
     .max(50, {
-      message: "Name must be less than 50 characters.",
+      error: "Name must be less than 50 characters.",
     }),
   status: z
     .string()
     .max(100, {
-      message: "Status must be less than 100 characters.",
+      error: "Status must be less than 100 characters.",
     })
     .optional(),
   bio: z
     .string()
     .max(500, {
-      message: "Bio must be less than 500 characters.",
+      error: "Bio must be less than 500 characters.",
     })
     .optional(),
   work: z
     .string()
     .max(100, {
-      message: "Work must be less than 100 characters.",
+      error: "Work must be less than 100 characters.",
     })
     .optional()
     .nullable(),
   website: z
     .string()
-    .url({ message: "Please enter a valid website URL." })
+    .url({ error: "Please enter a valid website URL." })
     .or(z.literal("")),
   social_x_link: z
     .string()
-    .url({ message: "Please enter a valid X URL." })
+    .url({ error: "Please enter a valid X URL." })
     .or(z.literal("")),
   is_public: z.boolean().optional(),
   slug: z.string().min(1, {
-    message: "Username is required.",
+    error: "Username is required.",
   }),
 });
 

--- a/apps/cursor/src/components/save-rule-button.tsx
+++ b/apps/cursor/src/components/save-rule-button.tsx
@@ -29,7 +29,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 const SaveRuleSchema = z.object({
-  fileName: z.string().min(1, "File name is required."),
+  fileName: z.string().min(1, { error: "File name is required." }),
 });
 
 type SaveRuleFormData = z.infer<typeof SaveRuleSchema>;


### PR DESCRIPTION
## Summary

- migrate server actions from deprecated `next-safe-action` `.schema(...)` to `.inputSchema(...)`
- update deprecated Zod schema APIs across actions/forms (including URL validation and error param usage)
- keep behavior equivalent while reducing deprecation warnings and preparing for future dependency upgrades

## References

- https://next-safe-action.dev/docs/migrations/v7-to-v8#-schema-method-renamed-to-inputschema
- https://zod.dev/v4/changelog