### PR TITLE
Stop tracking generated `next-env.d.ts`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .package-lock.json
 .env
 .react-email
+next-env.d.ts

--- a/apps/cursor/next-env.d.ts
+++ b/apps/cursor/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Ignore `next-env.d.ts` in git and remove the tracked file from the index, while keeping it referenced in `tsconfig.json` so TypeScript still loads it when regenerated.

## References

- Next.js docs on `next-env.d.ts` recommendation: https://nextjs.org/docs/app/api-reference/config/typescript#next-envdts