### PR TITLE
Feature/soft delete declined plugins

### DIFF
--- a/apps/cursor/src/actions/review-plugin.ts
+++ b/apps/cursor/src/actions/review-plugin.ts
@@ -16,7 +16,7 @@ export const approvePluginAction = adminActionClient
 
     const { error } = await supabase
       .from("plugins")
-      .update({ active: true })
+      .update({ active: true, status: "approved" })
       .eq("id", pluginId);
 
     if (error) {
@@ -70,7 +70,7 @@ export const declinePluginAction = adminActionClient
 
     const { error } = await supabase
       .from("plugins")
-      .delete()
+      .update({ active: false, status: "declined" })
       .eq("id", pluginId);
 
     if (error) {

--- a/apps/cursor/src/app/admin/plugins/page.tsx
+++ b/apps/cursor/src/app/admin/plugins/page.tsx
@@ -3,7 +3,7 @@ import { isAdmin } from "@/utils/admin";
 import { getSession } from "@/utils/supabase/auth";
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
-import { PluginReviewList } from "./plugin-review-list";
+import { PluginReviewTabs } from "./plugin-review-tabs";
 
 export const metadata: Metadata = {
   title: "Review Plugins | Admin",
@@ -26,24 +26,12 @@ export default async function AdminPluginsPage() {
       <div className="mx-auto w-full max-w-3xl">
         <div className="mb-10">
           <h1 className="marketing-page-title mb-3">Review Plugins</h1>
-          <p className="marketing-copy text-muted-foreground">
-            {plugins?.length ?? 0} pending{" "}
-            {plugins?.length === 1 ? "submission" : "submissions"}
-          </p>
         </div>
 
-        <PluginReviewList plugins={plugins ?? []} />
-
-        {declined && declined.length > 0 && (
-          <div className="mt-16">
-            <h2 className="mb-1 text-sm font-medium">Declined</h2>
-            <p className="mb-4 text-xs text-muted-foreground">
-              {declined.length} declined{" "}
-              {declined.length === 1 ? "plugin" : "plugins"}
-            </p>
-            <PluginReviewList plugins={declined} variant="declined" />
-          </div>
-        )}
+        <PluginReviewTabs
+          pending={plugins ?? []}
+          declined={declined ?? []}
+        />
       </div>
     </div>
   );

--- a/apps/cursor/src/app/admin/plugins/page.tsx
+++ b/apps/cursor/src/app/admin/plugins/page.tsx
@@ -1,4 +1,4 @@
-import { getPendingPlugins } from "@/data/queries";
+import { getDeclinedPlugins, getPendingPlugins } from "@/data/queries";
 import { isAdmin } from "@/utils/admin";
 import { getSession } from "@/utils/supabase/auth";
 import type { Metadata } from "next";
@@ -16,9 +16,10 @@ export default async function AdminPluginsPage() {
     redirect("/");
   }
 
-  const { data: plugins } = await getPendingPlugins({
-    since: "2026-03-16T00:00:00Z",
-  });
+  const [{ data: plugins }, { data: declined }] = await Promise.all([
+    getPendingPlugins({ since: "2026-03-16T00:00:00Z" }),
+    getDeclinedPlugins({ since: "2026-03-16T00:00:00Z" }),
+  ]);
 
   return (
     <div className="min-h-screen px-6 pt-24 md:pt-32 pb-32">
@@ -32,6 +33,17 @@ export default async function AdminPluginsPage() {
         </div>
 
         <PluginReviewList plugins={plugins ?? []} />
+
+        {declined && declined.length > 0 && (
+          <div className="mt-16">
+            <h2 className="mb-1 text-sm font-medium">Declined</h2>
+            <p className="mb-4 text-xs text-muted-foreground">
+              {declined.length} declined{" "}
+              {declined.length === 1 ? "plugin" : "plugins"}
+            </p>
+            <PluginReviewList plugins={declined} variant="declined" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/cursor/src/app/admin/plugins/plugin-review-list.tsx
+++ b/apps/cursor/src/app/admin/plugins/plugin-review-list.tsx
@@ -12,7 +12,10 @@ import { useAction } from "next-safe-action/hooks";
 import { useState } from "react";
 import { toast } from "sonner";
 
-function PluginReviewCard({ plugin }: { plugin: PluginRow }) {
+function PluginReviewCard({
+  plugin,
+  variant = "pending",
+}: { plugin: PluginRow; variant?: "pending" | "declined" }) {
   const [dismissed, setDismissed] = useState(false);
 
   const { execute: approve, isExecuting: isApproving } = useAction(
@@ -32,7 +35,7 @@ function PluginReviewCard({ plugin }: { plugin: PluginRow }) {
     declinePluginAction,
     {
       onSuccess: () => {
-        toast.success(`"${plugin.name}" declined and removed.`);
+        toast.success(`"${plugin.name}" declined.`);
         setDismissed(true);
       },
       onError: ({ error }) => {
@@ -50,7 +53,7 @@ function PluginReviewCard({ plugin }: { plugin: PluginRow }) {
   ];
 
   return (
-    <div className="rounded-lg border border-border bg-card p-5 shadow-cursor">
+    <div className={`rounded-lg border p-5 shadow-cursor ${variant === "declined" ? "border-border/50 bg-card/50 opacity-75" : "border-border bg-card"}`}>
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
           <Link
@@ -104,19 +107,21 @@ function PluginReviewCard({ plugin }: { plugin: PluginRow }) {
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={busy}
-            onClick={() => decline({ pluginId: plugin.id })}
-          >
-            {isDeclining ? (
-              <Loader2 className="size-3.5 animate-spin" />
-            ) : (
-              <Trash2 className="size-3.5" />
-            )}
-            <span className="ml-1.5">Decline</span>
-          </Button>
+          {variant === "pending" && (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={() => decline({ pluginId: plugin.id })}
+            >
+              {isDeclining ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="size-3.5" />
+              )}
+              <span className="ml-1.5">Decline</span>
+            </Button>
+          )}
           <Button
             size="sm"
             disabled={busy}
@@ -135,12 +140,15 @@ function PluginReviewCard({ plugin }: { plugin: PluginRow }) {
   );
 }
 
-export function PluginReviewList({ plugins }: { plugins: PluginRow[] }) {
+export function PluginReviewList({
+  plugins,
+  variant = "pending",
+}: { plugins: PluginRow[]; variant?: "pending" | "declined" }) {
   if (plugins.length === 0) {
     return (
       <div className="rounded-lg border border-border bg-card p-10 text-center shadow-cursor">
         <p className="text-sm text-muted-foreground">
-          No pending plugins to review.
+          No {variant} plugins to review.
         </p>
       </div>
     );
@@ -149,7 +157,7 @@ export function PluginReviewList({ plugins }: { plugins: PluginRow[] }) {
   return (
     <div className="space-y-3">
       {plugins.map((plugin) => (
-        <PluginReviewCard key={plugin.id} plugin={plugin} />
+        <PluginReviewCard key={plugin.id} plugin={plugin} variant={variant} />
       ))}
     </div>
   );

--- a/apps/cursor/src/app/admin/plugins/plugin-review-tabs.tsx
+++ b/apps/cursor/src/app/admin/plugins/plugin-review-tabs.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { PluginRow } from "@/data/queries";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import { PluginReviewList } from "./plugin-review-list";
+
+export function PluginReviewTabs({
+  pending,
+  declined,
+}: {
+  pending: PluginRow[];
+  declined: PluginRow[];
+}) {
+  return (
+    <Tabs defaultValue="pending">
+      <TabsList>
+        <TabsTrigger value="pending">
+          Pending{" "}
+          <span className="ml-1.5 text-xs text-muted-foreground">
+            {pending.length}
+          </span>
+        </TabsTrigger>
+        <TabsTrigger value="declined">
+          Declined{" "}
+          <span className="ml-1.5 text-xs text-muted-foreground">
+            {declined.length}
+          </span>
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="pending">
+        <PluginReviewList plugins={pending} variant="pending" />
+      </TabsContent>
+
+      <TabsContent value="declined">
+        <PluginReviewList plugins={declined} variant="declined" />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/apps/cursor/src/data/queries.ts
+++ b/apps/cursor/src/data/queries.ts
@@ -351,6 +351,7 @@ export type PluginRow = {
   author_avatar: string | null;
   owner_id: string | null;
   active: boolean;
+  status: "pending" | "approved" | "declined";
   plan: string;
   order: number;
   install_count: number;
@@ -452,6 +453,39 @@ export async function getPendingPlugins({
       .from("plugins")
       .select("*, plugin_components(*)")
       .eq("active", false)
+      .eq("status", "pending")
+      .order("created_at", { ascending: false })
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (since) {
+      query = query.gte("created_at", since);
+    }
+
+    const { data, error } = await query;
+    if (error) return { data: allData.length ? allData : null, error };
+    if (!data || data.length === 0) break;
+
+    allData = allData.concat(data as PluginRow[]);
+    if (data.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+
+  return { data: allData as PluginRow[], error: null };
+}
+
+export async function getDeclinedPlugins({
+  since,
+}: { since?: string } = {}) {
+  const supabase = await createClient();
+  const PAGE_SIZE = 100;
+  let allData: PluginRow[] = [];
+  let from = 0;
+
+  while (true) {
+    let query = supabase
+      .from("plugins")
+      .select("*, plugin_components(*)")
+      .eq("status", "declined")
       .order("created_at", { ascending: false })
       .range(from, from + PAGE_SIZE - 1);
 


### PR DESCRIPTION
- Replace hard delete with a `status` column (`pending` | `approved` | `declined`) so declined plugins are preserved instead of permanently removed
- Update `approvePluginAction` to set `status: "approved"` and `declinePluginAction` to set `status: "declined"` instead of deleting
- Add `getDeclinedPlugins` query to fetch declined plugins
- Add tabbed UI to the admin review page with "Pending" and "Declined" tabs, including counts
- Declined plugins can still be approved from the declined tab if needed
- Revalidate the individual plugin detail page (`/plugins/[slug]`) on approval