### PR TITLE
Remove Featured Plugins section from startpage

### DIFF
--- a/apps/cursor/src/app/page.tsx
+++ b/apps/cursor/src/app/page.tsx
@@ -2,7 +2,6 @@ import type { PluginCardData } from "@/components/plugins/plugin-card";
 import { Startpage } from "@/components/startpage";
 import {
   getFeaturedJobs,
-  getFeaturedPlugins,
   getForumPosts,
   getMembers,
   getPlugins,
@@ -59,7 +58,6 @@ function toPluginCard(p: NonNullable<Awaited<ReturnType<typeof getPlugins>>["dat
 export default async function Page() {
   const [
     { data: featuredJobs },
-    { data: featuredPluginsData },
     { data: totalUsers },
     { data: members },
     { data: popularPosts },
@@ -68,7 +66,6 @@ export default async function Page() {
     { data: forumPosts },
   ] = await Promise.all([
     getFeaturedJobs({ onlyPremium: true }),
-    getFeaturedPlugins({ onlyPremium: true }),
     getTotalUsers(),
     getMembers({ page: 1, limit: 12 }),
     getPopularPosts(),
@@ -76,8 +73,6 @@ export default async function Page() {
     getEvents(),
     getForumPosts(),
   ]);
-
-  const featuredPlugins = (featuredPluginsData ?? []).slice(0, 8).map(toPluginCard);
 
   const allPlugins = (allPluginsData ?? [])
     .map(toPluginCard)
@@ -112,7 +107,6 @@ export default async function Page() {
       <div className="w-full">
         <Suspense>
           <Startpage
-            featuredPlugins={featuredPlugins}
             popularPlugins={popularPlugins}
             allPlugins={allPlugins}
             recentPlugins={recentPlugins}

--- a/apps/cursor/src/components/startpage.tsx
+++ b/apps/cursor/src/components/startpage.tsx
@@ -23,7 +23,6 @@ function matchesSearch(term: string, ...fields: (string | undefined | null)[]) {
 import type { Event } from "@/lib/luma";
 
 export function Startpage({
-  featuredPlugins,
   popularPlugins,
   allPlugins,
   recentPlugins,
@@ -34,7 +33,6 @@ export function Startpage({
   popularPosts,
   forumPosts,
 }: {
-  featuredPlugins: PluginCardData[];
   popularPlugins: PluginCardData[];
   allPlugins: PluginCardData[];
   recentPlugins: PluginCardData[];
@@ -67,9 +65,9 @@ export function Startpage({
   );
 
   const filteredPlugins = useMemo(() => {
-    if (!isSearching) return featuredPlugins;
+    if (!isSearching) return [] as PluginCardData[];
     return pluginFuse.search(search).map((r) => r.item);
-  }, [search, isSearching, featuredPlugins, pluginFuse]);
+  }, [search, isSearching, pluginFuse]);
 
   const filteredJobs = useMemo(() => {
     if (!isSearching) return jobs;
@@ -133,21 +131,15 @@ export function Startpage({
             <GlobalSearchInput />
           </div>
 
-          {filteredPlugins.length > 0 && (
+          {isSearching && filteredPlugins.length > 0 && (
             <div className="mb-14">
               <div className="mb-5 flex items-center justify-between">
-                <h3 className="section-eyebrow">
-                  {isSearching ? "Plugins" : "Featured Plugins"}
-                </h3>
+                <h3 className="section-eyebrow">Plugins</h3>
                 <Link
-                  href={
-                    isSearching
-                      ? `/plugins?q=${encodeURIComponent(search)}`
-                      : "/plugins"
-                  }
+                  href={`/plugins?q=${encodeURIComponent(search)}`}
                   className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
                 >
-                  <span>{isSearching ? "See all results" : "View all"}</span>
+                  <span>See all results</span>
                   <svg
                     width="12"
                     height="13"
@@ -175,11 +167,9 @@ export function Startpage({
                 </Link>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-                {filteredPlugins
-                  .slice(0, isSearching ? 12 : 8)
-                  .map((plugin) => (
-                    <PluginCard key={plugin.slug} plugin={plugin} />
-                  ))}
+                {filteredPlugins.slice(0, 12).map((plugin) => (
+                  <PluginCard key={plugin.slug} plugin={plugin} />
+                ))}
               </div>
             </div>
           )}

--- a/apps/cursor/src/data/queries.ts
+++ b/apps/cursor/src/data/queries.ts
@@ -418,27 +418,6 @@ export async function getPluginBySlug(slug: string) {
   return { data: data as PluginRow | null, error };
 }
 
-export async function getFeaturedPlugins({
-  onlyPremium,
-}: {
-  onlyPremium?: boolean;
-} = {}) {
-  const supabase = await createClient();
-  const { data, error } = await supabase
-    .from("plugins")
-    .select("*, plugin_components(*)")
-    .limit(100)
-    .order("order", { ascending: false })
-    .order("install_count", { ascending: false })
-    .eq("active", true)
-    .or(onlyPremium ? "plan.eq.premium" : "plan.eq.featured,plan.eq.premium");
-
-  return {
-    data: (data as PluginRow[] | null)?.sort(() => Math.random() - 0.5) ?? null,
-    error,
-  };
-}
-
 export async function getPendingPlugins({
   since,
 }: { since?: string } = {}) {


### PR DESCRIPTION
Drop the premium-only Featured Plugins row and the associated data fetch; plugin results still render under the search input when a query is typed.