### PR TITLE
Migrate Supabase clients to new Publishable/Secret API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Fill in the required values:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `NEXT_PUBLIC_SUPABASE_URL` | Yes | Supabase project URL |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes | Supabase anon/public key |
-| `SUPABASE_SERVICE_ROLE_KEY` | Yes | Supabase service role key |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Yes | Supabase Publishable key (`sb_publishable_...`, replaces the legacy anon key) |
+| `SUPABASE_SECRET_KEY` | Yes | Supabase Secret key (`sb_secret_...`, replaces the legacy service role key) |
 | `RESEND_API_KEY` | No | Resend API key (emails) |
 | `NEXT_PUBLIC_APP_URL` | No | Defaults to `http://localhost:3000` |
 

--- a/apps/cursor/.env.example
+++ b/apps/cursor/.env.example
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_SUPABASE_URL=<your_supabase_project_url>
-NEXT_PUBLIC_SUPABASE_ANON_KEY=<your_supabase_anon_key>
-SUPABASE_SERVICE_ROLE_KEY=
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<your_supabase_publishable_key>
+SUPABASE_SECRET_KEY=<your_supabase_secret_key>
 
 RESEND_API_KEY=<your_resend_api_key>
 

--- a/apps/cursor/src/utils/supabase/admin-client.ts
+++ b/apps/cursor/src/utils/supabase/admin-client.ts
@@ -3,7 +3,7 @@ import { createServerClient } from "@supabase/ssr";
 export async function createClient() {
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    process.env.SUPABASE_SECRET_KEY!,
     {
       cookies: {
         getAll() {

--- a/apps/cursor/src/utils/supabase/client.ts
+++ b/apps/cursor/src/utils/supabase/client.ts
@@ -3,6 +3,6 @@ import { createBrowserClient } from '@supabase/ssr'
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
   )
 }

--- a/apps/cursor/src/utils/supabase/server.ts
+++ b/apps/cursor/src/utils/supabase/server.ts
@@ -17,8 +17,8 @@ export async function createClient({
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     admin
-      ? process.env.SUPABASE_SERVICE_ROLE_KEY!
-      : process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      ? process.env.SUPABASE_SECRET_KEY!
+      : process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
       auth,
       cookies: {


### PR DESCRIPTION
Rename NEXT_PUBLIC_SUPABASE_ANON_KEY -> NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY and SUPABASE_SERVICE_ROLE_KEY -> SUPABASE_SECRET_KEY across the browser, server, and admin Supabase clients, and update .env.example and README.