### PR TITLE
Fix profile cover upload and allow changing profile image

### DIFF
--- a/apps/cursor/next.config.mjs
+++ b/apps/cursor/next.config.mjs
@@ -63,6 +63,9 @@ const nextConfig = {
         hostname: "knhgkaawjfqqwmsgmxns.supabase.co",
       },
       {
+        hostname: "service.cursor.directory",
+      },
+      {
         hostname: "console.settlemint.com",
       },
       {

--- a/apps/cursor/src/components/company/company-hero.tsx
+++ b/apps/cursor/src/components/company/company-hero.tsx
@@ -3,7 +3,8 @@
 import { createClient } from "@/utils/supabase/client";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { type ChangeEvent, useRef } from "react";
+import { type ChangeEvent, useRef, useState } from "react";
+import { toast } from "sonner";
 
 export function CompanyHero({
   companyId,
@@ -16,46 +17,68 @@ export function CompanyHero({
 }) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
 
   const handleFileInput = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file?.type.startsWith("image/")) {
+    if (!file) return;
+
+    e.target.value = "";
+
+    if (!file.type.startsWith("image/")) {
+      toast.error("Please select an image file.");
       return;
     }
 
-    const MAX_FILE_SIZE = 1024 * 1024;
+    const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
     if (file.size > MAX_FILE_SIZE) {
+      toast.error("Image must be smaller than 5MB.");
       return;
     }
+
+    setIsUploading(true);
 
     try {
       const supabase = createClient();
       const fileExt = file.name.split(".").pop();
       const fileName = `${Math.random().toString(36).substring(2)}.${fileExt}`;
+      const path = `${companyId}/hero/${fileName}`;
 
-      await supabase.storage
+      const { error: uploadError } = await supabase.storage
         .from("avatars")
-        .upload(`${companyId}/hero/${fileName}`, file, {
+        .upload(path, file, {
           cacheControl: "3600",
           upsert: false,
         });
 
+      if (uploadError) {
+        throw uploadError;
+      }
+
       const {
         data: { publicUrl },
-      } = supabase.storage
-        .from("avatars")
-        .getPublicUrl(`${companyId}/hero/${fileName}`);
+      } = supabase.storage.from("avatars").getPublicUrl(path);
 
-      await supabase
+      const { error: updateError } = await supabase
         .from("companies")
-        .update({
-          hero: publicUrl,
-        })
+        .update({ hero: publicUrl })
         .eq("id", companyId);
 
+      if (updateError) {
+        throw updateError;
+      }
+
+      toast.success("Cover image updated.");
       router.refresh();
     } catch (error) {
-      console.error("Error uploading file:", error);
+      console.error("Error uploading cover image:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to upload cover image.",
+      );
+    } finally {
+      setIsUploading(false);
     }
   };
 
@@ -100,9 +123,10 @@ export function CompanyHero({
       {isOwner && (
         <button
           aria-label="Change cover image"
-          className="absolute right-4 top-4 flex h-9 items-center gap-2 rounded-full border border-border bg-card/92 px-3 text-sm text-muted-foreground backdrop-blur-sm transition-colors hover:bg-accent hover:text-foreground"
+          className="absolute right-4 top-4 flex h-9 items-center gap-2 rounded-full border border-border bg-card/92 px-3 text-sm text-muted-foreground backdrop-blur-sm transition-colors hover:bg-accent hover:text-foreground disabled:opacity-60"
           onClick={() => fileInputRef.current?.click()}
           type="button"
+          disabled={isUploading}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -130,7 +154,9 @@ export function CompanyHero({
               />
             </g>
           </svg>
-          <span className="hidden md:inline">Edit cover</span>
+          <span className="hidden md:inline">
+            {isUploading ? "Uploading..." : "Edit cover"}
+          </span>
         </button>
       )}
     </div>

--- a/apps/cursor/src/components/profile/editable-avatar.tsx
+++ b/apps/cursor/src/components/profile/editable-avatar.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { createClient } from "@/utils/supabase/client";
+import { useRouter } from "next/navigation";
+import { type ChangeEvent, useRef, useState } from "react";
+import { toast } from "sonner";
+
+export function EditableAvatar({
+  userId,
+  name,
+  image,
+  isOwner,
+}: {
+  userId: string;
+  name: string;
+  image?: string;
+  isOwner: boolean;
+}) {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleFileInput = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    e.target.value = "";
+
+    if (!file.type.startsWith("image/")) {
+      toast.error("Please select an image file.");
+      return;
+    }
+
+    const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+    if (file.size > MAX_FILE_SIZE) {
+      toast.error("Image must be smaller than 5MB.");
+      return;
+    }
+
+    setIsUploading(true);
+
+    try {
+      const supabase = createClient();
+      const fileExt = file.name.split(".").pop();
+      const fileName = `${Math.random().toString(36).substring(2)}.${fileExt}`;
+      const path = `${userId}/avatar/${fileName}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from("avatars")
+        .upload(path, file, {
+          cacheControl: "3600",
+          upsert: false,
+        });
+
+      if (uploadError) {
+        throw uploadError;
+      }
+
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from("avatars").getPublicUrl(path);
+
+      const { error: updateError } = await supabase
+        .from("users")
+        .update({ image: publicUrl })
+        .eq("id", userId);
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      toast.success("Profile image updated.");
+      router.refresh();
+    } catch (error) {
+      console.error("Error uploading profile image:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to upload profile image.",
+      );
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const openPicker = () => fileInputRef.current?.click();
+
+  const avatar = (
+    <Avatar className="size-20 border border-border bg-card md:size-24">
+      <AvatarImage src={image} className="object-cover" />
+      <AvatarFallback className="bg-muted text-lg font-medium text-foreground">
+        {name?.charAt(0)}
+      </AvatarFallback>
+    </Avatar>
+  );
+
+  if (!isOwner) {
+    return avatar;
+  }
+
+  return (
+    <div className="relative">
+      <input
+        ref={fileInputRef}
+        type="file"
+        className="hidden"
+        onChange={handleFileInput}
+        accept="image/*"
+      />
+
+      <button
+        type="button"
+        onClick={openPicker}
+        disabled={isUploading}
+        aria-label="Change profile image"
+        className="group relative rounded-full outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+      >
+        {avatar}
+
+        <span
+          className={`pointer-events-none absolute inset-0 flex items-center justify-center rounded-full bg-black/50 text-xs font-medium text-white transition-opacity ${
+            isUploading ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+          }`}
+        >
+          {isUploading ? "Uploading..." : "Change"}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/apps/cursor/src/components/profile/profile-header.tsx
+++ b/apps/cursor/src/components/profile/profile-header.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { formatNumber } from "@/utils/format";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import Link from "next/link";
 import { AmbassadorBadge } from "../ambassador-badge";
 import { EditProfileModal } from "../modals/edit-profile-modal";
+import { EditableAvatar } from "./editable-avatar";
 import { FollowButton } from "./follow-button";
 
 export function ProfileHeader({
@@ -41,13 +41,12 @@ export function ProfileHeader({
 }) {
   return (
     <div className="relative z-10 mt-4 flex flex-col gap-4 pb-2 md:mt-5 md:flex-row md:items-center md:gap-6">
-      <Avatar className="size-20 border border-border bg-card md:size-24">
-        <AvatarImage src={image} className="object-cover" />
-
-        <AvatarFallback className="bg-muted text-lg font-medium text-foreground">
-          {name?.charAt(0)}
-        </AvatarFallback>
-      </Avatar>
+      <EditableAvatar
+        userId={id}
+        name={name}
+        image={image}
+        isOwner={isOwner}
+      />
 
       <div className="flex min-w-0 flex-1 flex-col gap-2 md:pb-1">
         <div className="space-y-1">

--- a/apps/cursor/src/components/profile/profile-hero.tsx
+++ b/apps/cursor/src/components/profile/profile-hero.tsx
@@ -3,8 +3,8 @@
 import { createClient } from "@/utils/supabase/client";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { type ChangeEvent, useRef } from "react";
-
+import { type ChangeEvent, useRef, useState } from "react";
+import { toast } from "sonner";
 
 export function ProfileHero({
   userId,
@@ -17,49 +17,69 @@ export function ProfileHero({
 }) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
 
   const handleFileInput = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    console.log(file);
-    if (!file?.type.startsWith("image/")) {
+    if (!file) return;
+
+    // Always reset the input so selecting the same file again triggers change
+    e.target.value = "";
+
+    if (!file.type.startsWith("image/")) {
+      toast.error("Please select an image file.");
       return;
     }
 
-    const MAX_FILE_SIZE = 1024 * 1024; // 1MB in bytes
+    const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
     if (file.size > MAX_FILE_SIZE) {
+      toast.error("Image must be smaller than 5MB.");
       return;
     }
+
+    setIsUploading(true);
 
     try {
-      // Upload to Supabase Storage
       const supabase = createClient();
       const fileExt = file.name.split(".").pop();
       const fileName = `${Math.random().toString(36).substring(2)}.${fileExt}`;
+      const path = `${userId}/hero/${fileName}`;
 
-      await supabase.storage
+      const { error: uploadError } = await supabase.storage
         .from("avatars")
-        .upload(`${userId}/hero/${fileName}`, file, {
+        .upload(path, file, {
           cacheControl: "3600",
           upsert: false,
         });
 
-      // Get public URL
+      if (uploadError) {
+        throw uploadError;
+      }
+
       const {
         data: { publicUrl },
-      } = supabase.storage
-        .from("avatars")
-        .getPublicUrl(`${userId}/hero/${fileName}`);
+      } = supabase.storage.from("avatars").getPublicUrl(path);
 
-      await supabase
+      const { error: updateError } = await supabase
         .from("users")
-        .update({
-          hero: publicUrl,
-        })
+        .update({ hero: publicUrl })
         .eq("id", userId);
 
+      if (updateError) {
+        throw updateError;
+      }
+
+      toast.success("Cover image updated.");
       router.refresh();
     } catch (error) {
-      console.error("Error uploading file:", error);
+      console.error("Error uploading cover image:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to upload cover image.",
+      );
+    } finally {
+      setIsUploading(false);
     }
   };
 
@@ -104,9 +124,10 @@ export function ProfileHero({
       {isOwner && (
         <button
           aria-label="Change cover image"
-          className="absolute right-4 top-4 flex h-9 items-center gap-2 rounded-full border border-border bg-card/92 px-3 text-sm text-muted-foreground backdrop-blur-sm transition-colors hover:bg-accent hover:text-foreground"
+          className="absolute right-4 top-4 flex h-9 items-center gap-2 rounded-full border border-border bg-card/92 px-3 text-sm text-muted-foreground backdrop-blur-sm transition-colors hover:bg-accent hover:text-foreground disabled:opacity-60"
           onClick={() => fileInputRef.current?.click()}
           type="button"
+          disabled={isUploading}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -134,7 +155,9 @@ export function ProfileHero({
               />
             </g>
           </svg>
-          <span className="hidden md:inline">Edit cover</span>
+          <span className="hidden md:inline">
+            {isUploading ? "Uploading..." : "Edit cover"}
+          </span>
         </button>
       )}
     </div>


### PR DESCRIPTION
- Allow the Supabase custom domain `service.cursor.directory` in next/image remote patterns so uploaded hero/avatar images render instead of throwing a hostname-not-configured error.
- Surface storage upload and users-table update errors via sonner toasts, show an uploading state, and reset the file input so the same file can be picked twice on both profile and company hero.
- Add an EditableAvatar component that lets profile owners click their avatar to upload a new profile image (written to the avatars bucket and users.image).