### PR TITLE
feat: Add Spikes MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,6 +5,11 @@
     "env": {
       "SPIKES_TOKEN": "${SPIKES_TOKEN}",
       "SPIKES_API_URL": "${SPIKES_API_URL:-https://spikes.sh/api}"
+    },
+    "_metadata": {
+      "registry": "io.github.bierlingm/spikes",
+      "homepage": "https://spikes.sh",
+      "install": "npx -y spikes-mcp"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "spikes": {
+    "command": "npx",
+    "args": ["-y", "spikes-mcp"],
+    "env": {
+      "SPIKES_TOKEN": "${SPIKES_TOKEN}",
+      "SPIKES_API_URL": "${SPIKES_API_URL:-https://spikes.sh/api}"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the Spikes MCP server to the directory. Spikes provides structured UI feedback for AI-assisted building - reviewers click elements and rate them, agents read the JSON output and resolve feedback.

The server is available via npx as `spikes-mcp` and is registered on the MCP Registry as `io.github.bierlingm/spikes`.