### PR TITLE
Redirect removed directory sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ node_modules
 .DS_Store
 .package-lock.json
 .env
+.env.local
 .react-email
+.vercel/

--- a/apps/cursor/next.config.mjs
+++ b/apps/cursor/next.config.mjs
@@ -40,6 +40,36 @@ const nextConfig = {
         destination: "/plugins",
         permanent: true,
       },
+      {
+        source: "/jobs",
+        destination: "https://cursor.com/careers",
+        permanent: true,
+      },
+      {
+        source: "/jobs/:path*",
+        destination: "https://cursor.com/careers",
+        permanent: true,
+      },
+      {
+        source: "/events",
+        destination: "https://cursor.com/community",
+        permanent: true,
+      },
+      {
+        source: "/events/:path*",
+        destination: "https://cursor.com/community",
+        permanent: true,
+      },
+      {
+        source: "/board",
+        destination: "https://forum.cursor.com",
+        permanent: true,
+      },
+      {
+        source: "/board/:path*",
+        destination: "https://forum.cursor.com",
+        permanent: true,
+      },
     ];
   },
   images: {


### PR DESCRIPTION
## Summary
- Add permanent redirects for routes removed in #380: jobs to careers, events to community, board to the forum.
- Ignore `.env.local` and `.vercel/` in `.gitignore`.

## Test plan
- [ ] `/jobs` and `/jobs/*` redirect to `https://cursor.com/careers`
- [ ] `/events` and `/events/*` redirect to `https://cursor.com/community`
- [ ] `/board` and `/board/*` redirect to `https://forum.cursor.com`

Made with [Cursor](https://cursor.com)