### PR TITLE
Fall back to copy-to-clipboard for oversized plugin deeplinks

### DIFF
--- a/apps/cursor/src/components/plugins/plugin-detail.tsx
+++ b/apps/cursor/src/components/plugins/plugin-detail.tsx
@@ -73,6 +73,13 @@ function buildCommandDeepLink(name: string, content: string) {
   return `cursor://anysphere.cursor-deeplink/command?name=${encodeURIComponent(name)}&text=${encodeURIComponent(content)}`;
 }
 
+// Beyond this URL length, the cursor:// deeplink is unreliable: OS protocol
+// handlers and/or Cursor's URL parser silently drop or truncate the URL,
+// causing the editor to either no-op or throw "URI malformed" on its
+// decodeURIComponent call. Above the threshold we fall back to copy-to-clipboard
+// instead of a broken Add to Cursor button. See community-plugins#363.
+const MAX_DEEPLINK_URL_LENGTH = 8000;
+
 function toBase64(input: string): string {
   if (typeof Buffer !== "undefined") {
     return Buffer.from(input, "utf-8").toString("base64");
@@ -392,6 +399,9 @@ function RulesSection({
       <div className="space-y-3">
         {rules.map((rule) => {
           const isExpanded = expandedRule === rule.slug;
+          const ruleContent = rule.content ?? "";
+          const deepLink = buildRuleDeepLink(rule.slug, ruleContent);
+          const deepLinkUsable = deepLink.length <= MAX_DEEPLINK_URL_LENGTH;
 
           return (
             <div key={rule.slug} className="rounded-lg border border-border">
@@ -411,16 +421,21 @@ function RulesSection({
                     {rule.name}
                   </span>
                 </button>
-                <a
-                  href={buildRuleDeepLink(rule.slug, rule.content ?? "")}
-                  className="shrink-0 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onInstall();
-                  }}
-                >
-                  Add to Cursor
-                </a>
+                {deepLinkUsable ? (
+                  <a
+                    href={deepLink}
+                    className="shrink-0 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                    onClick={onInstall}
+                  >
+                    Add to Cursor
+                  </a>
+                ) : (
+                  <CopyButton
+                    text={ruleContent}
+                    onCopy={onInstall}
+                    title="Rule too large to install via deeplink — copy and paste into Cursor"
+                  />
+                )}
               </div>
 
               {isExpanded && (
@@ -542,7 +557,15 @@ function McpSection({
   );
 }
 
-function CopyButton({ text, onCopy }: { text: string; onCopy?: () => void }) {
+function CopyButton({
+  text,
+  onCopy,
+  title,
+}: {
+  text: string;
+  onCopy?: () => void;
+  title?: string;
+}) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
@@ -557,6 +580,7 @@ function CopyButton({ text, onCopy }: { text: string; onCopy?: () => void }) {
     <button
       type="button"
       onClick={handleCopy}
+      title={title}
       className="flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
     >
       {copied ? (
@@ -836,17 +860,35 @@ function GenericComponentSection({
               <div className="flex items-center justify-between gap-4">
                 <h3 className="text-sm font-medium">{comp.name}</h3>
                 {comp.content &&
-                  (type === "command" ? (
-                    <a
-                      href={buildCommandDeepLink(comp.slug, comp.content)}
-                      className="shrink-0 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-                      onClick={onInstall}
-                    >
-                      Add to Cursor
-                    </a>
-                  ) : (
-                    <CopyButton text={comp.content} onCopy={onInstall} />
-                  ))}
+                  (() => {
+                    if (type !== "command") {
+                      return (
+                        <CopyButton text={comp.content} onCopy={onInstall} />
+                      );
+                    }
+                    const deepLink = buildCommandDeepLink(
+                      comp.slug,
+                      comp.content,
+                    );
+                    if (deepLink.length > MAX_DEEPLINK_URL_LENGTH) {
+                      return (
+                        <CopyButton
+                          text={comp.content}
+                          onCopy={onInstall}
+                          title="Command too large to install via deeplink — copy and paste into Cursor"
+                        />
+                      );
+                    }
+                    return (
+                      <a
+                        href={deepLink}
+                        className="shrink-0 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                        onClick={onInstall}
+                      >
+                        Add to Cursor
+                      </a>
+                    );
+                  })()}
               </div>
               {comp.description && (
                 <p className="text-xs leading-5 text-muted-foreground">


### PR DESCRIPTION
The Add to Cursor button generates cursor:// URLs that embed the entire rule or command content in the text= query param. For content beyond a few KB the resulting URL exceeds practical limits of OS protocol handlers and Cursor's own URL parser, producing two failure modes the user can hit in the wild: the protocol handler silently drops the dispatch ("no action"), or it truncates mid %XX sequence and Cursor's decodeURIComponent throws ("URI malformed").

Above an 8000-char URL threshold we now render the existing CopyButton instead of a broken Add to Cursor link, with a tooltip that explains the fallback. The threshold was picked empirically: a 4.6KB rule that produces a ~6.5KB URL is reported to install fine, while 15KB+ rules consistently fail. Long-term the editor side should accept either base64 (matching the MCP install path) or token references so very large rules can install without copy-paste.

Closes #363.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change that only affects client-side install links; main risk is the chosen URL-length threshold potentially misclassifying edge cases.
> 
> **Overview**
> Prevents broken **“Add to Cursor”** actions for very large rules/commands by introducing a `MAX_DEEPLINK_URL_LENGTH` (8000) guard.
> 
> When a generated `cursor://` deeplink exceeds the limit, the UI now renders a `CopyButton` (with an explanatory tooltip) instead of the deeplink, while keeping the normal deeplink flow for smaller payloads. `CopyButton` was extended to accept an optional `title` for the tooltip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39da8654fe75b3bf96b9f3e2820a239f3dbefc1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->