### PR TITLE
Fix company submission failing with generic server error

### DIFF
--- a/apps/cursor/src/actions/upsert-company.ts
+++ b/apps/cursor/src/actions/upsert-company.ts
@@ -3,7 +3,7 @@
 import { redirect } from "next/navigation";
 import { z } from "zod";
 import { createClient } from "@/utils/supabase/server";
-import { authActionClient } from "./safe-action";
+import { ActionError, authActionClient } from "./safe-action";
 
 export const upsertCompanyAction = authActionClient
   .metadata({
@@ -41,46 +41,47 @@ export const upsertCompanyAction = authActionClient
     }) => {
       const supabase = await createClient();
 
+      // Only treat the request as an edit when a row with the provided id
+      // already exists. The form always generates a client-side nanoid for new
+      // companies, so the presence of `id` alone does not imply an edit.
       if (id) {
         const { data: existing } = await supabase
           .from("companies")
-          .select("id")
+          .select("id, owner_id")
           .eq("id", id)
-          .eq("owner_id", userId)
-          .single();
+          .maybeSingle();
 
-        if (!existing) {
-          throw new Error("You don't have permission to edit this company");
+        if (existing && existing.owner_id !== userId) {
+          throw new ActionError(
+            "You don't have permission to edit this company",
+          );
         }
       }
 
-      await supabase.from("companies").upsert(
-        {
-          id: id ?? undefined,
-          name,
-          image,
-          location,
-          slug: slug ?? undefined,
-          bio,
-          website,
-          social_x_link,
-          public: is_public,
-          owner_id: userId,
-        },
-        {
-          onConflict: "slug",
-        },
-      );
-
       const { data, error } = await supabase
         .from("companies")
+        .upsert(
+          {
+            id: id ?? undefined,
+            name,
+            image,
+            location,
+            slug: slug ?? undefined,
+            bio,
+            website,
+            social_x_link,
+            public: is_public,
+            owner_id: userId,
+          },
+          {
+            onConflict: "id",
+          },
+        )
         .select("id, slug")
-        .eq("id", id)
-        .eq("owner_id", userId)
         .single();
 
       if (error) {
-        throw new Error(error.message);
+        throw new ActionError(error.message);
       }
 
       if (shouldRedirect) {


### PR DESCRIPTION
The company form always generates a fresh client-side nanoid, which the upsert action treated as proof of an edit and rejected with a permission error. Treat the request as an edit only when a matching row exists, surface upsert errors as ActionError, and resolve conflicts by id.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches write/permission logic for `companies` upsert and changes conflict semantics to `onConflict: "id"`, which could affect updates/uniqueness behavior if assumptions differ from the DB schema.
> 
> **Overview**
> Fixes company submission/upsert to avoid treating any provided `id` as an edit: it now checks whether a `companies` row actually exists and only blocks when the existing row is owned by another user.
> 
> Changes the Supabase upsert to resolve conflicts by `id` (instead of `slug`) and surfaces permission/upsert failures as `ActionError` so users see specific messages rather than a generic server error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b7dafcef20e3e0777fdcb67006165f6b6ae050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->