### PR TITLE
Fix silent logo upload failure for signed-out users

### DIFF
--- a/apps/cursor/src/components/company/add-company-button.tsx
+++ b/apps/cursor/src/components/company/add-company-button.tsx
@@ -1,21 +1,46 @@
 "use client";
 
+import { usePathname, useRouter } from "next/navigation";
 import { parseAsBoolean, useQueryStates } from "nuqs";
+import { useEffect, useState } from "react";
+import { createClient } from "@/utils/supabase/client";
 import { Button } from "../ui/button";
 
 export function AddCompanyButton({ redirect }: { redirect?: boolean }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const supabase = createClient();
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+
   const [_, setAddCompany] = useQueryStates({
     addCompany: parseAsBoolean.withDefault(false),
     redirect: parseAsBoolean.withDefault(redirect ?? false),
   });
 
+  useEffect(() => {
+    async function getUser() {
+      const session = await supabase.auth.getSession();
+
+      setIsAuthenticated(Boolean(session.data.session));
+    }
+
+    getUser();
+  }, []);
+
+  const handleClick = () => {
+    // Adding a company requires an authenticated session: the save action is
+    // auth-guarded and the logo upload hits an auth-only storage policy. Send
+    // signed-out visitors to sign in instead of into a form that can't succeed.
+    if (!isAuthenticated) {
+      router.push(`/login?next=${pathname}`);
+      return;
+    }
+
+    setAddCompany({ addCompany: true, redirect });
+  };
+
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="lg"
-      onClick={() => setAddCompany({ addCompany: true, redirect })}
-    >
+    <Button type="button" variant="outline" size="lg" onClick={handleClick}>
       Add company
     </Button>
   );

--- a/apps/cursor/src/components/company/add-company-button.tsx
+++ b/apps/cursor/src/components/company/add-company-button.tsx
@@ -31,8 +31,12 @@ export function AddCompanyButton({ redirect }: { redirect?: boolean }) {
     // Adding a company requires an authenticated session: the save action is
     // auth-guarded and the logo upload hits an auth-only storage policy. Send
     // signed-out visitors to sign in instead of into a form that can't succeed.
-    if (!isAuthenticated) {
+    if (isAuthenticated === false) {
       router.push(`/login?next=${pathname}`);
+      return;
+    }
+
+    if (isAuthenticated === null) {
       return;
     }
 

--- a/apps/cursor/src/components/upload-logo.tsx
+++ b/apps/cursor/src/components/upload-logo.tsx
@@ -40,8 +40,10 @@ export default function UploadLogo({
     // Show an optimistic preview while the upload is in flight. It is reverted
     // below if the upload fails so the UI never shows an image that wasn't
     // actually saved.
+    let allowReaderPreview = true;
     const reader = new FileReader();
     reader.onload = (e) => {
+      if (!allowReaderPreview) return;
       setPreview(e.target?.result as string);
     };
     reader.readAsDataURL(file);
@@ -59,6 +61,7 @@ export default function UploadLogo({
 
       if (!user) {
         toast.error("Please sign in to upload an image.");
+        allowReaderPreview = false;
         setPreview(previousPreview);
         return;
       }
@@ -82,6 +85,7 @@ export default function UploadLogo({
         data: { publicUrl },
       } = supabase.storage.from("avatars").getPublicUrl(path);
 
+      allowReaderPreview = false;
       setPreview(publicUrl);
       onUpload?.(publicUrl);
     } catch (error) {
@@ -89,6 +93,7 @@ export default function UploadLogo({
       toast.error(
         error instanceof Error ? error.message : "Failed to upload image.",
       );
+      allowReaderPreview = false;
       setPreview(previousPreview);
     } finally {
       setIsUploading(false);

--- a/apps/cursor/src/components/upload-logo.tsx
+++ b/apps/cursor/src/components/upload-logo.tsx
@@ -3,6 +3,7 @@
 import { PlusIcon } from "lucide-react";
 import Image from "next/image";
 import { type ChangeEvent, type DragEvent, useRef, useState } from "react";
+import { toast } from "sonner";
 import { createClient } from "@/utils/supabase/client";
 
 interface UploadLogoProps {
@@ -23,33 +24,52 @@ export default function UploadLogo({
 
   const handleFile = async (file: File) => {
     if (!file.type.startsWith("image/")) {
+      toast.error("Please select an image file.");
       return;
     }
 
     const MAX_FILE_SIZE = 1024 * 1024; // 1MB in bytes
     if (file.size > MAX_FILE_SIZE) {
+      toast.error("Image must be smaller than 1MB.");
       return;
     }
 
+    const previousPreview = preview;
     setIsUploading(true);
 
-    try {
-      // Create preview
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const dataUrl = e.target?.result as string;
-        setPreview(dataUrl);
-      };
-      reader.readAsDataURL(file);
+    // Show an optimistic preview while the upload is in flight. It is reverted
+    // below if the upload fails so the UI never shows an image that wasn't
+    // actually saved.
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      setPreview(e.target?.result as string);
+    };
+    reader.readAsDataURL(file);
 
-      // Upload to Supabase Storage
+    try {
       const supabase = createClient();
+
+      // Uploading to the avatars bucket requires an authenticated session. The
+      // bucket's row-level security policy only allows the `authenticated`
+      // role, so without a session the request is sent as `anon` and Storage
+      // rejects it with "new row violates row-level security policy".
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        toast.error("Please sign in to upload an image.");
+        setPreview(previousPreview);
+        return;
+      }
+
       const fileExt = file.name.split(".").pop();
       const fileName = `${Math.random().toString(36).substring(2)}.${fileExt}`;
+      const path = `${prefix}/${fileName}`;
 
-      const { data, error } = await supabase.storage
+      const { error } = await supabase.storage
         .from("avatars")
-        .upload(`${prefix}/${fileName}`, file, {
+        .upload(path, file, {
           cacheControl: "3600",
           upsert: false,
         });
@@ -58,16 +78,18 @@ export default function UploadLogo({
         throw error;
       }
 
-      // Get public URL
       const {
         data: { publicUrl },
-      } = supabase.storage
-        .from("avatars")
-        .getPublicUrl(`${prefix}/${fileName}`);
+      } = supabase.storage.from("avatars").getPublicUrl(path);
 
+      setPreview(publicUrl);
       onUpload?.(publicUrl);
     } catch (error) {
       console.error("Error uploading file:", error);
+      toast.error(
+        error instanceof Error ? error.message : "Failed to upload image.",
+      );
+      setPreview(previousPreview);
     } finally {
       setIsUploading(false);
     }
@@ -147,6 +169,12 @@ export default function UploadLogo({
       ) : (
         <div className="absolute inset-0 flex flex-col items-center justify-center text-primary">
           <PlusIcon className="size-4" />
+        </div>
+      )}
+
+      {isUploading && (
+        <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-black/50 text-[10px] font-medium text-white">
+          Uploading...
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

The Add Company logo upload was silently failing with a confusing `StorageApiError: new row violates row-level security policy` (HTTP 400).

**Root cause:** The `avatars` storage bucket's only INSERT policy allows the `authenticated` role (`WITH CHECK (bucket_id = 'avatars')`). There is no path/folder restriction, so the `prefix` was never the issue. The Add Company flow was reachable while signed out, so the upload request was sent as the `anon` role and rejected by RLS. `UploadLogo` then swallowed the error (`console.error` only) while still rendering the local `FileReader` preview, so it looked like the upload had worked.

## Changes

- **`UploadLogo`**: verifies the session via `supabase.auth.getUser()` before uploading; surfaces upload + validation errors via `sonner` toasts; reverts the optimistic preview on failure so the UI never shows an unsaved image; adds an "Uploading…" state.
- **`AddCompanyButton`**: now auth-aware — signed-out visitors are redirected to `/login?next=…` instead of into a form whose upload and save (the `upsertCompanyAction` is already auth-guarded) can never succeed. Follows the existing client-side auth pattern (`mcps-edit-button.tsx`).

## Test plan

- [ ] Signed out: clicking "Add company" on `/companies` redirects to `/login`.
- [ ] Signed in: logo upload succeeds and the saved company shows the logo.
- [ ] Force an upload failure (e.g. expired session): an error toast appears and the preview reverts instead of showing a phantom image.
- [ ] Non-image / >1MB file shows a validation toast.

## Notes / follow-ups

- There is no `middleware.ts` in the repo, which `@supabase/ssr` normally uses to refresh sessions; expired sessions can leave the browser client unauthenticated. Worth adding separately.
- Console also shows a benign `Missing Description or aria-describedby for {DialogContent}` a11y warning on the dialog — not addressed here.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UX and auth checks around company creation and storage uploads; no server policy or data model changes in this diff.
> 
> **Overview**
> Fixes **Add company** and logo upload behavior when the session is missing or still loading.
> 
> **`AddCompanyButton`** now treats auth as three states: signed-out users go to `/login?next=…` only when `isAuthenticated === false`, and clicks are ignored while auth is still `null` (avoids opening the flow before `getSession` finishes).
> 
> **`UploadLogo`** gates the optimistic `FileReader` preview with `allowReaderPreview` so late `onload` callbacks cannot show a local image after sign-in failure, upload errors, or once the real public URL is set—preview stays aligned with what was actually stored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85468b714a696200ff8d89e35b1a6fe3c2d58a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->