### PR TITLE
feat: add owner-only company deletion flow

### DIFF
--- a/apps/cursor/src/actions/delete-company.ts
+++ b/apps/cursor/src/actions/delete-company.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { createClient } from "@/utils/supabase/server";
+import { ActionError, authActionClient } from "./safe-action";
+
+export const deleteCompanyAction = authActionClient
+  .metadata({
+    actionName: "delete-company",
+  })
+  .schema(
+    z.object({
+      id: z.string(),
+      slug: z.string(),
+    }),
+  )
+  .action(async ({ parsedInput: { id, slug }, ctx: { userId } }) => {
+    const supabase = await createClient();
+
+    const { data: company, error: companyError } = await supabase
+      .from("companies")
+      .select("id, owner_id")
+      .eq("id", id)
+      .single();
+
+    if (companyError || !company) {
+      throw new ActionError("Company not found.");
+    }
+
+    if (company.owner_id !== userId) {
+      throw new ActionError("You do not have permission to delete this company.");
+    }
+
+    const { error: unlinkMcpsError } = await supabase
+      .from("mcps")
+      .update({ company_id: null })
+      .eq("company_id", id)
+      .eq("owner_id", userId);
+
+    if (unlinkMcpsError) {
+      throw new ActionError(`Failed to unlink MCPs: ${unlinkMcpsError.message}`);
+    }
+
+    const { error: deleteError } = await supabase
+      .from("companies")
+      .delete()
+      .eq("id", id)
+      .eq("owner_id", userId);
+
+    if (deleteError) {
+      throw new ActionError(`Failed to delete company: ${deleteError.message}`);
+    }
+
+    revalidatePath("/companies");
+    revalidatePath(`/c/${slug}`);
+    revalidatePath("/");
+
+    return { success: true };
+  });

--- a/apps/cursor/src/components/company/company-header.tsx
+++ b/apps/cursor/src/components/company/company-header.tsx
@@ -1,4 +1,5 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { DeleteCompanyButton } from "./delete-company-button";
 import { EditCompanyModal } from "../modals/edit-company-modal";
 
 export function CompanyHeader({
@@ -47,7 +48,8 @@ export function CompanyHeader({
       </div>
 
       {isOwner && (
-        <div className="self-start md:ml-auto md:self-center">
+        <div className="flex self-start gap-2 md:ml-auto md:self-center">
+          <DeleteCompanyButton id={id} slug={slug} />
           <EditCompanyModal
             data={{
               id,

--- a/apps/cursor/src/components/company/delete-company-button.tsx
+++ b/apps/cursor/src/components/company/delete-company-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useAction } from "next-safe-action/hooks";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { deleteCompanyAction } from "@/actions/delete-company";
+import { Button } from "@/components/ui/button";
+
+export function DeleteCompanyButton({
+  id,
+  slug,
+}: {
+  id: string;
+  slug: string;
+}) {
+  const router = useRouter();
+
+  const { execute, isExecuting } = useAction(deleteCompanyAction, {
+    onSuccess: () => {
+      toast.success("Company deleted.");
+      router.push("/companies");
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Failed to delete company.");
+    },
+  });
+
+  const onDelete = () => {
+    const confirmed = window.confirm(
+      "Delete this company? This cannot be undone.",
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    execute({ id, slug });
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="destructive"
+      className="h-8 rounded-full"
+      onClick={onDelete}
+      disabled={isExecuting}
+    >
+      {isExecuting ? "Deleting..." : "Delete Company"}
+    </Button>
+  );
+}


### PR DESCRIPTION
## What
- add a new authenticated `deleteCompanyAction` to delete companies only when `owner_id` matches the current user
- unlink related MCP listings before deletion by setting `mcps.company_id` to `null`
- add a `DeleteCompanyButton` with a native browser confirmation popup and success/error toasts
- show the delete button only for company owners in the company header

## Why
Users can accidentally create multiple companies by clicking create several times. This adds a safe owner-managed way to clean up extra company records.

<img width="1349" height="631" alt="Screenshot 2026-05-26 at 14 15 38" src="https://github.com/user-attachments/assets/a0f3b880-e881-49a5-8bf7-5f2b7ce366fe" />

(see https://cursor.directory/companies)

## Verification
- typecheck passes via `/opt/homebrew/bin/bun run typecheck` in `apps/cursor`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes company records and mutates related MCP associations; authorization is owner-scoped but destructive operations warrant careful review.
> 
> **Overview**
> Adds an **owner-only** way to remove a company from the app: a destructive control on the company header (next to edit) that confirms via the browser, then runs a new authenticated server action.
> 
> The action loads the company, rejects non-owners, **clears `company_id` on the owner’s related MCP rows** (does not delete MCPs), deletes the company row, and revalidates `/companies`, the company slug route, and `/`. Success redirects to `/companies` with a toast; errors surface via toast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4de20bf25766e20a4a5a0a943c2b98b289f281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->