### PR TITLE
Fix OG image 500s and stop install rate limits logging as errors

### DIFF
--- a/apps/cursor/src/actions/track-install.ts
+++ b/apps/cursor/src/actions/track-install.ts
@@ -4,7 +4,11 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { installGlobalLimit, installPerPluginLimit } from "@/lib/rate-limit";
 import { createClient as createAdminClient } from "@/utils/supabase/admin-client";
-import { ActionError, actionClient } from "./safe-action";
+import { actionClient } from "./safe-action";
+
+export type TrackInstallResult =
+  | { tracked: true }
+  | { tracked: false; rateLimited: true };
 
 export const trackInstallAction = actionClient
   .metadata({
@@ -23,7 +27,7 @@ export const trackInstallAction = actionClient
     ]);
 
     if (!global.success || !perPlugin.success) {
-      throw new ActionError("Rate limit exceeded. Please try again later.");
+      return { tracked: false, rateLimited: true } satisfies TrackInstallResult;
     }
 
     const admin = await createAdminClient();
@@ -34,4 +38,6 @@ export const trackInstallAction = actionClient
 
     revalidatePath("/");
     revalidatePath(`/plugins/${slug}`);
+
+    return { tracked: true } satisfies TrackInstallResult;
   });

--- a/apps/cursor/src/app/c/[slug]/opengraph-image.tsx
+++ b/apps/cursor/src/app/c/[slug]/opengraph-image.tsx
@@ -1,9 +1,15 @@
 import { getCompanyProfile } from "@/data/queries";
-import { createOGResponse, OG, OGLayout } from "@/lib/og";
+import {
+  createOGResponse,
+  OG,
+  OGLayout,
+  resolveOgImageUrl,
+} from "@/lib/og";
 
 export const alt = "Company Profile";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image({
   params,
@@ -30,10 +36,12 @@ export default async function Image({
     );
   }
 
+  const logoUrl = resolveOgImageUrl(data.image);
+
   return createOGResponse(
     <OGLayout>
       <div style={{ display: "flex", alignItems: "center", gap: 40 }}>
-        {data.image && (
+        {logoUrl && (
           <div
             style={{
               display: "flex",
@@ -48,7 +56,7 @@ export default async function Image({
             }}
           >
             <img
-              src={data.image}
+              src={logoUrl}
               width={104}
               height={104}
               style={{ borderRadius: 14, objectFit: "contain" }}
@@ -66,6 +74,7 @@ export default async function Image({
         >
           <div
             style={{
+              display: "flex",
               fontSize: 52,
               fontWeight: 700,
               color: OG.text,
@@ -106,6 +115,7 @@ export default async function Image({
           {data.bio && (
             <div
               style={{
+                display: "flex",
                 fontSize: 22,
                 color: OG.textTertiary,
                 lineHeight: 1.4,

--- a/apps/cursor/src/app/companies/opengraph-image.tsx
+++ b/apps/cursor/src/app/companies/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { createListingOG, OG } from "@/lib/og";
 export const alt = "Companies";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createListingOG("Companies", "Companies using Cursor");

--- a/apps/cursor/src/app/login/opengraph-image.tsx
+++ b/apps/cursor/src/app/login/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { createListingOG, OG } from "@/lib/og";
 export const alt = "Sign In";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createListingOG("Sign In", "Sign in to Cursor Directory");

--- a/apps/cursor/src/app/members/opengraph-image.tsx
+++ b/apps/cursor/src/app/members/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { createListingOG, OG } from "@/lib/og";
 export const alt = "Members";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createListingOG(

--- a/apps/cursor/src/app/opengraph-image.tsx
+++ b/apps/cursor/src/app/opengraph-image.tsx
@@ -1,8 +1,14 @@
-import { CursorIcon, createOGResponse, OG, OGLayout } from "@/lib/og";
+import {
+  CursorIcon,
+  createOGResponse,
+  OG,
+  OGLayout,
+} from "@/lib/og";
 
 export const alt = "Cursor Directory";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createOGResponse(
@@ -20,6 +26,7 @@ export default async function Image() {
         <CursorIcon size={80} />
         <div
           style={{
+            display: "flex",
             fontSize: 56,
             fontWeight: 700,
             color: OG.text,
@@ -31,6 +38,7 @@ export default async function Image() {
         </div>
         <div
           style={{
+            display: "flex",
             fontSize: 26,
             color: OG.textSecondary,
             lineHeight: 1.4,

--- a/apps/cursor/src/app/plugins/[slug]/opengraph-image.tsx
+++ b/apps/cursor/src/app/plugins/[slug]/opengraph-image.tsx
@@ -1,15 +1,17 @@
 import { getPluginBySlug } from "@/data/queries";
 import {
-  CursorIcon,
   createOGResponse,
   formatCount,
   OG,
   OGLayout,
+  resolveOgImageUrl,
 } from "@/lib/og";
 
 export const alt = "Plugin";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+// Must be a literal — Next.js segment config does not accept imported values.
+export const revalidate = 86400;
 
 export default async function Image({
   params,
@@ -35,6 +37,8 @@ export default async function Image({
       </OGLayout>,
     );
   }
+
+  const logoUrl = resolveOgImageUrl(data.logo);
 
   const components = data.plugin_components ?? [];
   const typeCounts: Record<string, number> = {};
@@ -62,9 +66,9 @@ export default async function Image({
               padding: 6,
             }}
           >
-            {data.logo ? (
+            {logoUrl ? (
               <img
-                src={data.logo}
+                src={logoUrl}
                 width={60}
                 height={60}
                 style={{ borderRadius: 10, objectFit: "contain" }}
@@ -72,6 +76,7 @@ export default async function Image({
             ) : (
               <span
                 style={{
+                  display: "flex",
                   fontSize: 32,
                   fontWeight: 700,
                   color: OG.textSecondary,
@@ -90,6 +95,7 @@ export default async function Image({
           >
             <div
               style={{
+                display: "flex",
                 fontSize: 48,
                 fontWeight: 700,
                 color: OG.text,
@@ -100,7 +106,13 @@ export default async function Image({
               {data.name}
             </div>
             {data.author_name && (
-              <div style={{ fontSize: 22, color: OG.textSecondary }}>
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 22,
+                  color: OG.textSecondary,
+                }}
+              >
                 by {data.author_name}
               </div>
             )}
@@ -110,6 +122,7 @@ export default async function Image({
         {data.description && (
           <div
             style={{
+              display: "flex",
               fontSize: 24,
               color: OG.textSecondary,
               lineHeight: 1.4,
@@ -146,13 +159,15 @@ export default async function Image({
               <polyline points="7 10 12 15 17 10" />
               <line x1="12" y1="15" x2="12" y2="3" />
             </svg>
-            <span style={{ fontWeight: 700 }}>
+            <span style={{ display: "flex", fontWeight: 700 }}>
               {formatCount(data.install_count)}
             </span>
           </div>
 
           {componentSummary && (
-            <div style={{ fontSize: 20, color: OG.textTertiary }}>
+            <div
+              style={{ display: "flex", fontSize: 20, color: OG.textTertiary }}
+            >
               {componentSummary}
             </div>
           )}
@@ -164,6 +179,7 @@ export default async function Image({
               <div
                 key={kw}
                 style={{
+                  display: "flex",
                   fontSize: 16,
                   color: OG.textSecondary,
                   padding: "6px 14px",

--- a/apps/cursor/src/app/plugins/new/opengraph-image.tsx
+++ b/apps/cursor/src/app/plugins/new/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { createListingOG, OG } from "@/lib/og";
 export const alt = "Submit a Plugin";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createListingOG(

--- a/apps/cursor/src/app/plugins/opengraph-image.tsx
+++ b/apps/cursor/src/app/plugins/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { createListingOG, OG } from "@/lib/og";
 export const alt = "Plugins";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createListingOG(

--- a/apps/cursor/src/app/u/[slug]/opengraph-image.tsx
+++ b/apps/cursor/src/app/u/[slug]/opengraph-image.tsx
@@ -1,9 +1,15 @@
 import { getUserProfile } from "@/data/queries";
-import { createOGResponse, OG, OGLayout } from "@/lib/og";
+import {
+  createOGResponse,
+  OG,
+  OGLayout,
+  resolveOgImageUrl,
+} from "@/lib/og";
 
 export const alt = "User Profile";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image({
   params,
@@ -30,12 +36,14 @@ export default async function Image({
     );
   }
 
+  const avatarUrl = resolveOgImageUrl(data.image);
+
   return createOGResponse(
     <OGLayout>
       <div style={{ display: "flex", alignItems: "center", gap: 40 }}>
-        {data.image && (
+        {avatarUrl && (
           <img
-            src={data.image}
+            src={avatarUrl}
             width={140}
             height={140}
             style={{ borderRadius: "50%", border: `1px solid ${OG.border}` }}
@@ -52,6 +60,7 @@ export default async function Image({
         >
           <div
             style={{
+              display: "flex",
               fontSize: 52,
               fontWeight: 700,
               color: OG.text,
@@ -65,6 +74,7 @@ export default async function Image({
           {data.work && (
             <div
               style={{
+                display: "flex",
                 fontSize: 24,
                 color: OG.textSecondary,
                 lineHeight: 1.3,
@@ -77,6 +87,7 @@ export default async function Image({
           {data.bio && (
             <div
               style={{
+                display: "flex",
                 fontSize: 22,
                 color: OG.textTertiary,
                 lineHeight: 1.4,

--- a/apps/cursor/src/components/plugins/plugin-detail.tsx
+++ b/apps/cursor/src/components/plugins/plugin-detail.tsx
@@ -13,6 +13,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useAction } from "next-safe-action/hooks";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 import { trackInstallAction } from "@/actions/track-install";
 import { CursorDeepLink } from "@/components/cursor-deeplink";
 import { Card, CardContent } from "@/components/ui/card";
@@ -211,10 +212,17 @@ export function PluginDetailView({ plugin }: { plugin: PluginRow }) {
     });
   }, [plugin.owner_id]);
 
-  const { execute: trackInstall } = useAction(trackInstallAction);
+  const { execute: trackInstall } = useAction(trackInstallAction, {
+    onSuccess: ({ data }) => {
+      if (data?.tracked) {
+        setInstallCount((c) => c + 1);
+      } else if (data?.rateLimited) {
+        toast("Too many installs right now. Please try again in a bit.");
+      }
+    },
+  });
 
   const handleInstall = useCallback(() => {
-    setInstallCount((c) => c + 1);
     trackInstall({ pluginId: plugin.id, slug: plugin.slug });
   }, [plugin.id, plugin.slug, trackInstall]);
 

--- a/apps/cursor/src/lib/og.tsx
+++ b/apps/cursor/src/lib/og.tsx
@@ -17,6 +17,39 @@ export const OG = {
   cardBg: "#1b1913",
 };
 
+const OG_CACHE_CONTROL =
+  "public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800";
+
+function ogSiteOrigin(): string {
+  const configured = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "");
+  if (configured) return configured;
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return "https://cursor.directory";
+}
+
+/**
+ * Satori requires absolute http(s) image URLs. Plugin logos are sometimes stored
+ * as site-relative paths (e.g. `assets/logo.png`).
+ */
+export function resolveOgImageUrl(
+  src: string | null | undefined,
+): string | null {
+  const trimmed = src?.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+  } catch {
+    // Fall through — treat as a path relative to the site origin.
+  }
+
+  const path = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return new URL(path, ogSiteOrigin()).toString();
+}
+
 export async function loadFonts() {
   const [regular, bold] = await Promise.all([
     readFile(
@@ -121,6 +154,9 @@ export async function createOGResponse(element: ReactElement) {
     width: OG.width,
     height: OG.height,
     fonts,
+    headers: {
+      "Cache-Control": OG_CACHE_CONTROL,
+    },
   });
 }
 
@@ -130,6 +166,7 @@ export async function createListingOG(title: string, subtitle: string) {
       <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
         <div
           style={{
+            display: "flex",
             fontSize: 64,
             fontWeight: 700,
             color: OG.text,
@@ -141,6 +178,7 @@ export async function createListingOG(title: string, subtitle: string) {
         </div>
         <div
           style={{
+            display: "flex",
             fontSize: 28,
             color: OG.textSecondary,
             lineHeight: 1.4,


### PR DESCRIPTION
## Summary
- Fix Open Graph image route 500s (~5% of OG traffic) caused by relative logo/avatar URLs and Satori's strict layout requirements.
- Normalize image `src` to absolute URLs via `resolveOgImageUrl`, add explicit `display: flex` on multi-child nodes, and set `Cache-Control` on `ImageResponse` so social crawlers hit cached PNGs instead of regenerating.
- Add `revalidate = 86400` to the OG routes. Listing OG routes (`/`, `/plugins`, `/members`, `/login`, `/companies`, `/plugins/new`) prerender as ISR-static; the slug routes (`/plugins/[slug]`, `/u/[slug]`, `/c/[slug]`) stay dynamic but still benefit from response caching.
- `track-install` now returns a non-throwing result (`{ tracked }` / `{ rateLimited }`) instead of throwing `ActionError`, so expected install rate limiting no longer floods Vercel error-level logs. The client only increments the count on success and shows a toast when rate limited.

## Background
Production log analysis on `anysphere/cursor-directory` surfaced two recurring issues:
- `/plugins/[slug]/opengraph-image` returning 500 (`Image source must be an absolute URL`, `Expected <div> to have explicit "display: flex"`).
- High volume of `Action error: Rate limit exceeded` error logs from the `track-install` server action — expected UX, but logged as errors.

## Test plan
- [x] `npm run build` succeeds; build route table shows listing OG routes as Static (`○`, revalidate 1d) and slug OG routes as Dynamic (`ƒ`).
- [x] `prerender-manifest.json` confirms `initialRevalidateSeconds: 86400` and `Cache-Control` headers on prerendered OG routes.
- [ ] Verify social preview images render for a plugin with a relative logo URL.
- [ ] Confirm hitting the install rate limit shows a toast and does not emit an error-level log.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted rendering and logging/UX fixes; install counting behavior is slightly stricter (no optimistic bump on rate limit) but RPC path is unchanged on success.
> 
> **Overview**
> Fixes **Open Graph** route 500s and cuts **noise from expected install rate limits** in production logs.
> 
> OG images now use **`resolveOgImageUrl`** so Satori gets absolute `http(s)` URLs when logos/avatars are stored as site-relative paths. Several OG JSX nodes gain explicit **`display: flex`** for Satori layout rules. **`createOGResponse`** sets day-long **`Cache-Control`** on PNG responses, and OG routes export **`revalidate = 86400`** so listing images can ISR and crawlers reuse cached output.
> 
> **`track-install`** stops throwing on rate limit: it returns **`{ tracked: true }`** or **`{ tracked: false, rateLimited: true }`**. **`plugin-detail`** only bumps the install count when tracking succeeds and shows a **toast** when rate limited, instead of optimistically incrementing and logging server errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913f049acb2a00dbf4efba226f9fd3323cc57e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->