### PR TITLE
OG image hardening, install rate-limit logging, and duplicate-company prevention

### DIFF
--- a/apps/cursor/src/actions/track-install.ts
+++ b/apps/cursor/src/actions/track-install.ts
@@ -4,7 +4,11 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { installGlobalLimit, installPerPluginLimit } from "@/lib/rate-limit";
 import { createClient as createAdminClient } from "@/utils/supabase/admin-client";
-import { ActionError, actionClient } from "./safe-action";
+import { actionClient } from "./safe-action";
+
+export type TrackInstallResult =
+  | { tracked: true }
+  | { tracked: false; rateLimited: true };
 
 export const trackInstallAction = actionClient
   .metadata({
@@ -23,7 +27,7 @@ export const trackInstallAction = actionClient
     ]);
 
     if (!global.success || !perPlugin.success) {
-      throw new ActionError("Rate limit exceeded. Please try again later.");
+      return { tracked: false, rateLimited: true } satisfies TrackInstallResult;
     }
 
     const admin = await createAdminClient();
@@ -34,4 +38,6 @@ export const trackInstallAction = actionClient
 
     revalidatePath("/");
     revalidatePath(`/plugins/${slug}`);
+
+    return { tracked: true } satisfies TrackInstallResult;
   });

--- a/apps/cursor/src/actions/upsert-company.ts
+++ b/apps/cursor/src/actions/upsert-company.ts
@@ -5,6 +5,10 @@ import { z } from "zod";
 import { createClient } from "@/utils/supabase/server";
 import { ActionError, authActionClient } from "./safe-action";
 
+// Postgres unique_violation. Raised when an insert/update collides with the
+// case-insensitive company name index (companies_name_key_unique).
+const UNIQUE_VIOLATION = "23505";
+
 export const upsertCompanyAction = authActionClient
   .metadata({
     actionName: "upsert-company",
@@ -27,7 +31,7 @@ export const upsertCompanyAction = authActionClient
     async ({
       parsedInput: {
         id,
-        name,
+        name: rawName,
         image,
         slug,
         location,
@@ -41,6 +45,9 @@ export const upsertCompanyAction = authActionClient
     }) => {
       const supabase = await createClient();
 
+      const name = rawName.trim();
+      const nameKey = name.toLowerCase();
+
       // Only treat the request as an edit when a row with the provided id
       // already exists. The form always generates a client-side nanoid for new
       // companies, so the presence of `id` alone does not imply an edit.
@@ -51,36 +58,84 @@ export const upsertCompanyAction = authActionClient
           .eq("id", id)
           .maybeSingle();
 
-        if (existing && existing.owner_id !== userId) {
-          throw new ActionError(
-            "You don't have permission to edit this company",
-          );
+        if (existing) {
+          if (existing.owner_id !== userId) {
+            throw new ActionError(
+              "You don't have permission to edit this company",
+            );
+          }
+
+          const { data, error } = await supabase
+            .from("companies")
+            .update({
+              name,
+              image,
+              location,
+              bio,
+              website,
+              social_x_link,
+              public: is_public,
+            })
+            .eq("id", id)
+            .select("id, slug")
+            .single();
+
+          if (error) {
+            if (error.code === UNIQUE_VIOLATION) {
+              throw new ActionError("A company with this name already exists.");
+            }
+            throw new ActionError(error.message);
+          }
+
+          if (shouldRedirect) {
+            redirect(`/c/${data?.slug}`);
+          }
+
+          return data;
         }
       }
 
+      // New company. Insert directly so the case-insensitive unique index can
+      // reject duplicates even under concurrent/double submissions. The slug is
+      // assigned by the `generate_company_slug` trigger.
       const { data, error } = await supabase
         .from("companies")
-        .upsert(
-          {
-            id: id ?? undefined,
-            name,
-            image,
-            location,
-            slug: slug ?? undefined,
-            bio,
-            website,
-            social_x_link,
-            public: is_public,
-            owner_id: userId,
-          },
-          {
-            onConflict: "id",
-          },
-        )
+        .insert({
+          id: id ?? undefined,
+          name,
+          image,
+          location,
+          slug: slug ?? undefined,
+          bio,
+          website,
+          social_x_link,
+          public: is_public,
+          owner_id: userId,
+        })
         .select("id, slug")
         .single();
 
       if (error) {
+        // A company with this name already exists. Reuse it instead of creating
+        // a duplicate so retries/double-clicks resolve to the same record.
+        if (error.code === UNIQUE_VIOLATION) {
+          const { data: existing } = await supabase
+            .from("companies")
+            .select("id, slug")
+            .eq("name_key", nameKey)
+            .maybeSingle();
+
+          if (existing) {
+            if (shouldRedirect) {
+              redirect(`/c/${existing.slug}`);
+            }
+
+            return existing;
+          }
+
+          throw new ActionError("A company with this name already exists.");
+        }
+
         throw new ActionError(error.message);
       }
 

--- a/apps/cursor/src/app/c/[slug]/opengraph-image.tsx
+++ b/apps/cursor/src/app/c/[slug]/opengraph-image.tsx
@@ -1,9 +1,15 @@
 import { getCompanyProfile } from "@/data/queries";
-import { createOGResponse, OG, OGLayout } from "@/lib/og";
+import {
+  createOGResponse,
+  OG,
+  OGLayout,
+  resolveOgImageUrl,
+} from "@/lib/og";
 
 export const alt = "Company Profile";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image({
   params,
@@ -30,10 +36,12 @@ export default async function Image({
     );
   }
 
+  const logoUrl = resolveOgImageUrl(data.image);
+
   return createOGResponse(
     <OGLayout>
       <div style={{ display: "flex", alignItems: "center", gap: 40 }}>
-        {data.image && (
+        {logoUrl && (
           <div
             style={{
               display: "flex",
@@ -48,7 +56,7 @@ export default async function Image({
             }}
           >
             <img
-              src={data.image}
+              src={logoUrl}
               width={104}
               height={104}
               style={{ borderRadius: 14, objectFit: "contain" }}
@@ -66,6 +74,7 @@ export default async function Image({
         >
           <div
             style={{
+              display: "flex",
               fontSize: 52,
               fontWeight: 700,
               color: OG.text,
@@ -106,6 +115,7 @@ export default async function Image({
           {data.bio && (
             <div
               style={{
+                display: "flex",
                 fontSize: 22,
                 color: OG.textTertiary,
                 lineHeight: 1.4,

--- a/apps/cursor/src/app/companies/opengraph-image.tsx
+++ b/apps/cursor/src/app/companies/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { createListingOG, OG } from "@/lib/og";
 export const alt = "Companies";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createListingOG("Companies", "Companies using Cursor");

--- a/apps/cursor/src/app/login/opengraph-image.tsx
+++ b/apps/cursor/src/app/login/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { createListingOG, OG } from "@/lib/og";
 export const alt = "Sign In";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createListingOG("Sign In", "Sign in to Cursor Directory");

--- a/apps/cursor/src/app/members/opengraph-image.tsx
+++ b/apps/cursor/src/app/members/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { createListingOG, OG } from "@/lib/og";
 export const alt = "Members";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createListingOG(

--- a/apps/cursor/src/app/opengraph-image.tsx
+++ b/apps/cursor/src/app/opengraph-image.tsx
@@ -1,8 +1,14 @@
-import { CursorIcon, createOGResponse, OG, OGLayout } from "@/lib/og";
+import {
+  CursorIcon,
+  createOGResponse,
+  OG,
+  OGLayout,
+} from "@/lib/og";
 
 export const alt = "Cursor Directory";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createOGResponse(
@@ -20,6 +26,7 @@ export default async function Image() {
         <CursorIcon size={80} />
         <div
           style={{
+            display: "flex",
             fontSize: 56,
             fontWeight: 700,
             color: OG.text,
@@ -31,6 +38,7 @@ export default async function Image() {
         </div>
         <div
           style={{
+            display: "flex",
             fontSize: 26,
             color: OG.textSecondary,
             lineHeight: 1.4,

--- a/apps/cursor/src/app/plugins/[slug]/opengraph-image.tsx
+++ b/apps/cursor/src/app/plugins/[slug]/opengraph-image.tsx
@@ -1,15 +1,17 @@
 import { getPluginBySlug } from "@/data/queries";
 import {
-  CursorIcon,
   createOGResponse,
   formatCount,
   OG,
   OGLayout,
+  resolveOgImageUrl,
 } from "@/lib/og";
 
 export const alt = "Plugin";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+// Must be a literal — Next.js segment config does not accept imported values.
+export const revalidate = 86400;
 
 export default async function Image({
   params,
@@ -35,6 +37,8 @@ export default async function Image({
       </OGLayout>,
     );
   }
+
+  const logoUrl = resolveOgImageUrl(data.logo);
 
   const components = data.plugin_components ?? [];
   const typeCounts: Record<string, number> = {};
@@ -62,9 +66,9 @@ export default async function Image({
               padding: 6,
             }}
           >
-            {data.logo ? (
+            {logoUrl ? (
               <img
-                src={data.logo}
+                src={logoUrl}
                 width={60}
                 height={60}
                 style={{ borderRadius: 10, objectFit: "contain" }}
@@ -72,6 +76,7 @@ export default async function Image({
             ) : (
               <span
                 style={{
+                  display: "flex",
                   fontSize: 32,
                   fontWeight: 700,
                   color: OG.textSecondary,
@@ -90,6 +95,7 @@ export default async function Image({
           >
             <div
               style={{
+                display: "flex",
                 fontSize: 48,
                 fontWeight: 700,
                 color: OG.text,
@@ -100,7 +106,13 @@ export default async function Image({
               {data.name}
             </div>
             {data.author_name && (
-              <div style={{ fontSize: 22, color: OG.textSecondary }}>
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 22,
+                  color: OG.textSecondary,
+                }}
+              >
                 by {data.author_name}
               </div>
             )}
@@ -110,6 +122,7 @@ export default async function Image({
         {data.description && (
           <div
             style={{
+              display: "flex",
               fontSize: 24,
               color: OG.textSecondary,
               lineHeight: 1.4,
@@ -146,13 +159,15 @@ export default async function Image({
               <polyline points="7 10 12 15 17 10" />
               <line x1="12" y1="15" x2="12" y2="3" />
             </svg>
-            <span style={{ fontWeight: 700 }}>
+            <span style={{ display: "flex", fontWeight: 700 }}>
               {formatCount(data.install_count)}
             </span>
           </div>
 
           {componentSummary && (
-            <div style={{ fontSize: 20, color: OG.textTertiary }}>
+            <div
+              style={{ display: "flex", fontSize: 20, color: OG.textTertiary }}
+            >
               {componentSummary}
             </div>
           )}
@@ -164,6 +179,7 @@ export default async function Image({
               <div
                 key={kw}
                 style={{
+                  display: "flex",
                   fontSize: 16,
                   color: OG.textSecondary,
                   padding: "6px 14px",

--- a/apps/cursor/src/app/plugins/new/opengraph-image.tsx
+++ b/apps/cursor/src/app/plugins/new/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { createListingOG, OG } from "@/lib/og";
 export const alt = "Submit a Plugin";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createListingOG(

--- a/apps/cursor/src/app/plugins/opengraph-image.tsx
+++ b/apps/cursor/src/app/plugins/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { createListingOG, OG } from "@/lib/og";
 export const alt = "Plugins";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image() {
   return createListingOG(

--- a/apps/cursor/src/app/u/[slug]/opengraph-image.tsx
+++ b/apps/cursor/src/app/u/[slug]/opengraph-image.tsx
@@ -1,9 +1,15 @@
 import { getUserProfile } from "@/data/queries";
-import { createOGResponse, OG, OGLayout } from "@/lib/og";
+import {
+  createOGResponse,
+  OG,
+  OGLayout,
+  resolveOgImageUrl,
+} from "@/lib/og";
 
 export const alt = "User Profile";
 export const size = { width: OG.width, height: OG.height };
 export const contentType = "image/png";
+export const revalidate = 86400;
 
 export default async function Image({
   params,
@@ -30,12 +36,14 @@ export default async function Image({
     );
   }
 
+  const avatarUrl = resolveOgImageUrl(data.image);
+
   return createOGResponse(
     <OGLayout>
       <div style={{ display: "flex", alignItems: "center", gap: 40 }}>
-        {data.image && (
+        {avatarUrl && (
           <img
-            src={data.image}
+            src={avatarUrl}
             width={140}
             height={140}
             style={{ borderRadius: "50%", border: `1px solid ${OG.border}` }}
@@ -52,6 +60,7 @@ export default async function Image({
         >
           <div
             style={{
+              display: "flex",
               fontSize: 52,
               fontWeight: 700,
               color: OG.text,
@@ -65,6 +74,7 @@ export default async function Image({
           {data.work && (
             <div
               style={{
+                display: "flex",
                 fontSize: 24,
                 color: OG.textSecondary,
                 lineHeight: 1.3,
@@ -77,6 +87,7 @@ export default async function Image({
           {data.bio && (
             <div
               style={{
+                display: "flex",
                 fontSize: 22,
                 color: OG.textTertiary,
                 lineHeight: 1.4,

--- a/apps/cursor/src/components/forms/company.tsx
+++ b/apps/cursor/src/components/forms/company.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { nanoid } from "nanoid";
 import { useAction } from "next-safe-action/hooks";
 import { parseAsBoolean, useQueryState } from "nuqs";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { upsertCompanyAction } from "@/actions/upsert-company";
@@ -87,7 +88,9 @@ export function CompanyForm({
     },
   });
 
-  const id = data?.id ?? nanoid();
+  // Generate the id once per mount. Recomputing it on every render would change
+  // the submitted id (and logo upload path) and defeat duplicate prevention.
+  const [id] = useState(() => data?.id ?? nanoid());
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),

--- a/apps/cursor/src/components/plugins/plugin-detail.tsx
+++ b/apps/cursor/src/components/plugins/plugin-detail.tsx
@@ -13,6 +13,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useAction } from "next-safe-action/hooks";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 import { trackInstallAction } from "@/actions/track-install";
 import { CursorDeepLink } from "@/components/cursor-deeplink";
 import { Card, CardContent } from "@/components/ui/card";
@@ -211,10 +212,17 @@ export function PluginDetailView({ plugin }: { plugin: PluginRow }) {
     });
   }, [plugin.owner_id]);
 
-  const { execute: trackInstall } = useAction(trackInstallAction);
+  const { execute: trackInstall } = useAction(trackInstallAction, {
+    onSuccess: ({ data }) => {
+      if (data?.tracked) {
+        setInstallCount((c) => c + 1);
+      } else if (data?.rateLimited) {
+        toast("Too many installs right now. Please try again in a bit.");
+      }
+    },
+  });
 
   const handleInstall = useCallback(() => {
-    setInstallCount((c) => c + 1);
     trackInstall({ pluginId: plugin.id, slug: plugin.slug });
   }, [plugin.id, plugin.slug, trackInstall]);
 

--- a/apps/cursor/src/lib/og.tsx
+++ b/apps/cursor/src/lib/og.tsx
@@ -17,6 +17,39 @@ export const OG = {
   cardBg: "#1b1913",
 };
 
+const OG_CACHE_CONTROL =
+  "public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800";
+
+function ogSiteOrigin(): string {
+  const configured = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "");
+  if (configured) return configured;
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return "https://cursor.directory";
+}
+
+/**
+ * Satori requires absolute http(s) image URLs. Plugin logos are sometimes stored
+ * as site-relative paths (e.g. `assets/logo.png`).
+ */
+export function resolveOgImageUrl(
+  src: string | null | undefined,
+): string | null {
+  const trimmed = src?.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+  } catch {
+    // Fall through — treat as a path relative to the site origin.
+  }
+
+  const path = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return new URL(path, ogSiteOrigin()).toString();
+}
+
 export async function loadFonts() {
   const [regular, bold] = await Promise.all([
     readFile(
@@ -121,6 +154,9 @@ export async function createOGResponse(element: ReactElement) {
     width: OG.width,
     height: OG.height,
     fonts,
+    headers: {
+      "Cache-Control": OG_CACHE_CONTROL,
+    },
   });
 }
 
@@ -130,6 +166,7 @@ export async function createListingOG(title: string, subtitle: string) {
       <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
         <div
           style={{
+            display: "flex",
             fontSize: 64,
             fontWeight: 700,
             color: OG.text,
@@ -141,6 +178,7 @@ export async function createListingOG(title: string, subtitle: string) {
         </div>
         <div
           style={{
+            display: "flex",
             fontSize: 28,
             color: OG.textSecondary,
             lineHeight: 1.4,

--- a/supabase/migrations/20260526_companies_unique_name.sql
+++ b/supabase/migrations/20260526_companies_unique_name.sql
@@ -1,0 +1,11 @@
+-- Normalize existing names so surrounding whitespace can't create near-duplicates
+UPDATE public.companies SET name = btrim(name) WHERE name <> btrim(name);
+
+-- Normalized key used to enforce case-insensitive uniqueness of company names
+ALTER TABLE public.companies
+  ADD COLUMN IF NOT EXISTS name_key text
+  GENERATED ALWAYS AS (lower(btrim(name))) STORED;
+
+-- One company per normalized name (prevents the duplicate explosion at the DB level)
+CREATE UNIQUE INDEX IF NOT EXISTS companies_name_key_unique
+  ON public.companies (name_key);


### PR DESCRIPTION
## Summary

This branch bundles three fixes:

### Prevent duplicate company records
- Companies could be created repeatedly (e.g. 7 separate "Contentful" rows) because the upsert only conflicted on a freshly-minted client-side id, while a `BEFORE INSERT` trigger silently uniquified slugs (`contentful-1`, `contentful-2`, …) instead of rejecting dupes.
- Adds a normalized `name_key` generated column + a case-insensitive unique index (`companies_name_key_unique`) so duplicates are rejected at the DB level, even under concurrent/double submits (migration `supabase/migrations/20260526_companies_unique_name.sql`).
- Rewrites `upsert-company` to treat a request as an edit only when the row already exists, and to **reuse** the existing company on a name conflict (idempotent) instead of creating a duplicate.
- Generates the company form id once per mount so it stops changing on every render (which previously also broke the logo upload path).

### OG image hardening
- Fixes OG image 500s and makes the shared `lib/og.tsx` rendering more resilient across the various `opengraph-image` routes.

### Install rate-limit logging
- Stops install rate-limit hits from being logged as errors in `track-install`.

## Test plan
- [ ] Submitting the same company name twice (incl. rapid double-click) resolves to a single company instead of creating duplicates.
- [ ] Editing an existing company still works and preserves its slug.
- [ ] OG images render without 500s across home, company, user, and plugin routes.
- [ ] Install rate-limit responses no longer surface as errors in logs.

Note: the company de-dup migration and a one-time cleanup of 260 pre-existing duplicate rows were already applied to the production database; the cleanup is reversible via the `companies_dedup_backup_20260526` table.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Company insert/upsert behavior and a schema migration affect data integrity and concurrent creates; OG and install changes are lower risk but touch many routes and user-visible counts.
> 
> **Overview**
> This PR hardens **company creation**, **Open Graph images**, and **plugin install tracking** in three parallel tracks.
> 
> **Duplicate companies:** A migration adds a stored `name_key` (`lower(btrim(name))`) and a unique index so names are unique case-insensitively at the database. `upsert-company` now treats edits only when the row exists (not merely when a client `id` is present), uses explicit `update`/`insert` instead of id-only upsert, trims names, maps unique violations to user-facing errors on edit, and on insert **reuses** the existing company by `name_key` so double-submit/retry is idempotent. The company form keeps a stable `nanoid` per mount so upload paths and submitted ids do not change every render.
> 
> **OG images:** Shared `lib/og` gains `resolveOgImageUrl` for absolute Satori URLs, `Cache-Control` on generated images, and `revalidate = 86400` on OG routes. Profile/plugin OG templates use resolved logo/avatar URLs and add `display: "flex"` on text nodes for layout reliability.
> 
> **Install rate limits:** `track-install` returns `{ tracked, rateLimited }` instead of throwing; the plugin detail page bumps install count only when tracked and shows a toast when rate-limited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6baf7c51be0996e482ea400d71ef5279005a7306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->