### PR TITLE
Fix duplicate companies: enforce unique names + searchable company picker

### DIFF
--- a/apps/cursor/package.json
+++ b/apps/cursor/package.json
@@ -32,6 +32,7 @@
     "@vercel/firewall": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.38.0",
     "fuse.js": "^7.3.0",

--- a/apps/cursor/src/actions/upsert-company.ts
+++ b/apps/cursor/src/actions/upsert-company.ts
@@ -5,6 +5,10 @@ import { z } from "zod";
 import { createClient } from "@/utils/supabase/server";
 import { ActionError, authActionClient } from "./safe-action";
 
+// Postgres unique_violation. Raised when an insert/update collides with the
+// case-insensitive company name index (companies_name_key_unique).
+const UNIQUE_VIOLATION = "23505";
+
 export const upsertCompanyAction = authActionClient
   .metadata({
     actionName: "upsert-company",
@@ -27,7 +31,7 @@ export const upsertCompanyAction = authActionClient
     async ({
       parsedInput: {
         id,
-        name,
+        name: rawName,
         image,
         slug,
         location,
@@ -41,6 +45,9 @@ export const upsertCompanyAction = authActionClient
     }) => {
       const supabase = await createClient();
 
+      const name = rawName.trim();
+      const nameKey = name.toLowerCase();
+
       // Only treat the request as an edit when a row with the provided id
       // already exists. The form always generates a client-side nanoid for new
       // companies, so the presence of `id` alone does not imply an edit.
@@ -51,36 +58,84 @@ export const upsertCompanyAction = authActionClient
           .eq("id", id)
           .maybeSingle();
 
-        if (existing && existing.owner_id !== userId) {
-          throw new ActionError(
-            "You don't have permission to edit this company",
-          );
+        if (existing) {
+          if (existing.owner_id !== userId) {
+            throw new ActionError(
+              "You don't have permission to edit this company",
+            );
+          }
+
+          const { data, error } = await supabase
+            .from("companies")
+            .update({
+              name,
+              image,
+              location,
+              bio,
+              website,
+              social_x_link,
+              public: is_public,
+            })
+            .eq("id", id)
+            .select("id, slug")
+            .single();
+
+          if (error) {
+            if (error.code === UNIQUE_VIOLATION) {
+              throw new ActionError("A company with this name already exists.");
+            }
+            throw new ActionError(error.message);
+          }
+
+          if (shouldRedirect) {
+            redirect(`/c/${data?.slug}`);
+          }
+
+          return data;
         }
       }
 
+      // New company. Insert directly so the case-insensitive unique index can
+      // reject duplicates even under concurrent/double submissions. The slug is
+      // assigned by the `generate_company_slug` trigger.
       const { data, error } = await supabase
         .from("companies")
-        .upsert(
-          {
-            id: id ?? undefined,
-            name,
-            image,
-            location,
-            slug: slug ?? undefined,
-            bio,
-            website,
-            social_x_link,
-            public: is_public,
-            owner_id: userId,
-          },
-          {
-            onConflict: "id",
-          },
-        )
+        .insert({
+          id: id ?? undefined,
+          name,
+          image,
+          location,
+          slug: slug ?? undefined,
+          bio,
+          website,
+          social_x_link,
+          public: is_public,
+          owner_id: userId,
+        })
         .select("id, slug")
         .single();
 
       if (error) {
+        // A company with this name already exists. Reuse it instead of creating
+        // a duplicate so retries/double-clicks resolve to the same record.
+        if (error.code === UNIQUE_VIOLATION) {
+          const { data: existing } = await supabase
+            .from("companies")
+            .select("id, slug")
+            .eq("name_key", nameKey)
+            .maybeSingle();
+
+          if (existing) {
+            if (shouldRedirect) {
+              redirect(`/c/${existing.slug}`);
+            }
+
+            return existing;
+          }
+
+          throw new ActionError("A company with this name already exists.");
+        }
+
         throw new ActionError(error.message);
       }
 

--- a/apps/cursor/src/actions/upsert-company.ts
+++ b/apps/cursor/src/actions/upsert-company.ts
@@ -16,7 +16,10 @@ export const upsertCompanyAction = authActionClient
   .schema(
     z.object({
       id: z.string().optional(),
-      name: z.string(),
+      name: z
+        .string()
+        .trim()
+        .min(2, { message: "Name must be at least 2 characters." }),
       image: z.string().url().nullable(),
       slug: z.string().optional(),
       location: z.string().nullable(),
@@ -31,7 +34,7 @@ export const upsertCompanyAction = authActionClient
     async ({
       parsedInput: {
         id,
-        name: rawName,
+        name,
         image,
         slug,
         location,
@@ -45,7 +48,6 @@ export const upsertCompanyAction = authActionClient
     }) => {
       const supabase = await createClient();
 
-      const name = rawName.trim();
       const nameKey = name.toLowerCase();
 
       // Only treat the request as an edit when a row with the provided id

--- a/apps/cursor/src/components/company/company-list.tsx
+++ b/apps/cursor/src/components/company/company-list.tsx
@@ -10,6 +10,7 @@ import { CompanyCard } from "./company-card";
 
 export function CompanyList({ data }: { data?: Company[] | null }) {
   const [companies, setCompanies] = useState<Company[]>(data ?? []);
+  const [isSearching, setIsSearching] = useState(false);
   const [search, setSearch] = useQueryState("q");
 
   useEffect(() => {
@@ -17,18 +18,20 @@ export function CompanyList({ data }: { data?: Company[] | null }) {
 
     // No search: show the full server-rendered list.
     if (!term) {
+      setIsSearching(false);
       setCompanies(data ?? []);
       return;
     }
 
     // With a search term, query the entire companies table rather than
     // filtering only the rows that happen to be loaded on the page.
-    setCompanies([]);
+    setIsSearching(true);
     let active = true;
     const handle = setTimeout(async () => {
       const results = await searchCompanies(term);
       if (active) {
         setCompanies(results);
+        setIsSearching(false);
       }
     }, 200);
 
@@ -47,6 +50,10 @@ export function CompanyList({ data }: { data?: Company[] | null }) {
           {companies?.map((company) => (
             <CompanyCard key={company.id} company={company} />
           ))}
+        </div>
+      ) : isSearching ? (
+        <div className="mt-24 text-center text-sm text-muted-foreground">
+          Searching...
         </div>
       ) : (
         <div className="mt-24 flex flex-col items-center">

--- a/apps/cursor/src/components/company/company-list.tsx
+++ b/apps/cursor/src/components/company/company-list.tsx
@@ -2,6 +2,7 @@
 
 import { useQueryState } from "nuqs";
 import { useEffect, useState } from "react";
+import { searchCompanies } from "@/data/client-queries";
 import { SearchInput } from "../search-input";
 import { Button } from "../ui/button";
 import type { Company } from "./company-card";
@@ -12,12 +13,29 @@ export function CompanyList({ data }: { data?: Company[] | null }) {
   const [search, setSearch] = useQueryState("q");
 
   useEffect(() => {
-    const filteredCompanies = data?.filter((company) =>
-      company.name.toLowerCase().includes(search?.toLowerCase() ?? ""),
-    );
+    const term = search?.trim() ?? "";
 
-    setCompanies(filteredCompanies ?? []);
-  }, [search]);
+    // No search: show the full server-rendered list.
+    if (!term) {
+      setCompanies(data ?? []);
+      return;
+    }
+
+    // With a search term, query the entire companies table rather than
+    // filtering only the rows that happen to be loaded on the page.
+    let active = true;
+    const handle = setTimeout(async () => {
+      const results = await searchCompanies(term);
+      if (active) {
+        setCompanies(results);
+      }
+    }, 200);
+
+    return () => {
+      active = false;
+      clearTimeout(handle);
+    };
+  }, [search, data]);
 
   return (
     <div className="mt-8">

--- a/apps/cursor/src/components/company/company-list.tsx
+++ b/apps/cursor/src/components/company/company-list.tsx
@@ -23,6 +23,7 @@ export function CompanyList({ data }: { data?: Company[] | null }) {
 
     // With a search term, query the entire companies table rather than
     // filtering only the rows that happen to be loaded on the page.
+    setCompanies([]);
     let active = true;
     const handle = setTimeout(async () => {
       const results = await searchCompanies(term);

--- a/apps/cursor/src/components/company/company-select.tsx
+++ b/apps/cursor/src/components/company/company-select.tsx
@@ -143,6 +143,7 @@ export function CompanySelect({
       return;
     }
 
+    setResults([]);
     let active = true;
     setLoading(true);
 

--- a/apps/cursor/src/components/company/company-select.tsx
+++ b/apps/cursor/src/components/company/company-select.tsx
@@ -1,15 +1,23 @@
 "use client";
 
+import { Check, ChevronsUpDown } from "lucide-react";
 import { parseAsBoolean, useQueryStates } from "nuqs";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
 import { createClient } from "@/utils/supabase/client";
 import { AddCompanyButton } from "./add-company-button";
 
@@ -25,73 +33,220 @@ export function CompanySelect({
   value?: string;
   onChange: (value: string) => void;
 }) {
-  const [selectedCompany, setSelectedCompany] = useState<Company | null>(null);
-  const [companies, setCompanies] = useState<Company[]>([]);
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<Company | null>(null);
+  const [ownCompanies, setOwnCompanies] = useState<Company[]>([]);
+  const [results, setResults] = useState<Company[]>([]);
+  const [loading, setLoading] = useState(false);
+
   const [{ reload }, setQueryStates] = useQueryStates({
     reload: parseAsBoolean.withDefault(false),
     addCompany: parseAsBoolean.withDefault(false),
   });
 
+  // Load the current user's own companies (shown first). Re-runs when a new
+  // company is added via the "Add company" modal (which flips `reload`).
   useEffect(() => {
-    async function fetchCompanies() {
+    let active = true;
+
+    async function loadOwn() {
       const {
         data: { session },
       } = await supabase.auth.getSession();
 
-      if (session) {
-        const { data } = await supabase
-          .from("companies")
-          .select("id, name")
-          .eq("owner_id", session.user.id)
-          .order("created_at", { ascending: false });
+      if (!session) {
+        return;
+      }
 
-        if (data) {
-          setCompanies(data);
+      const { data } = await supabase
+        .from("companies")
+        .select("id, name")
+        .eq("owner_id", session.user.id)
+        .order("created_at", { ascending: false });
 
-          const initialCompany = data.find((c) => c.id === value) || data[0];
-          setSelectedCompany(initialCompany);
-          onChange(initialCompany?.id ?? "");
-        }
+      if (active && data) {
+        setOwnCompanies(data);
       }
     }
 
-    fetchCompanies();
+    loadOwn();
 
     if (reload) {
       setQueryStates({ reload: false, addCompany: false });
     }
-  }, [reload]);
+
+    return () => {
+      active = false;
+    };
+  }, [reload, supabase, setQueryStates]);
+
+  // Resolve the display name for the currently selected company id, even when
+  // it was created by someone else and isn't in the user's own list.
+  useEffect(() => {
+    let active = true;
+
+    if (!value) {
+      setSelected(null);
+      return;
+    }
+
+    const known =
+      ownCompanies.find((c) => c.id === value) ??
+      results.find((c) => c.id === value);
+
+    if (known) {
+      setSelected(known);
+      return;
+    }
+
+    async function resolve() {
+      const { data } = await supabase
+        .from("companies")
+        .select("id, name")
+        .eq("id", value)
+        .maybeSingle();
+
+      if (active && data) {
+        setSelected(data);
+      }
+    }
+
+    resolve();
+
+    return () => {
+      active = false;
+    };
+  }, [value, ownCompanies, results, supabase]);
+
+  // Debounced search across all companies by name (RLS allows public read).
+  useEffect(() => {
+    const term = query.trim();
+
+    if (!term) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+
+    const handle = setTimeout(async () => {
+      const { data } = await supabase
+        .from("companies")
+        .select("id, name")
+        .ilike("name", `%${term}%`)
+        .order("name", { ascending: true })
+        .limit(20);
+
+      if (active) {
+        setResults(data ?? []);
+        setLoading(false);
+      }
+    }, 250);
+
+    return () => {
+      active = false;
+      clearTimeout(handle);
+    };
+  }, [query, supabase]);
+
+  const handleSelect = (company: Company) => {
+    setSelected(company);
+    onChange(company.id);
+    setQuery("");
+    setOpen(false);
+  };
+
+  const term = query.trim().toLowerCase();
+  const ownFiltered = term
+    ? ownCompanies.filter((c) => c.name.toLowerCase().includes(term))
+    : ownCompanies;
+  const ownIds = new Set(ownFiltered.map((c) => c.id));
+  const otherResults = results.filter((c) => !ownIds.has(c.id));
 
   return (
     <div className="flex items-center gap-4">
-      <Select
-        key={selectedCompany?.id}
-        value={selectedCompany?.id}
-        onValueChange={(value) => {
-          const company = companies.find((c) => c.id === value);
-          setSelectedCompany(company || null);
-          onChange(company?.id ?? "");
-        }}
-      >
-        <SelectTrigger
-          className="w-full border-border"
-          disabled={companies.length === 0}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-full justify-between border-border font-normal"
+          >
+            <span className={cn("truncate", !selected && "text-[#878787]")}>
+              {selected?.name ?? "Select company"}
+            </span>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-[var(--radix-popover-trigger-width)] p-0"
         >
-          <SelectValue placeholder="Select company" />
-        </SelectTrigger>
-        {companies.length > 0 && (
-          <SelectContent className="max-h-[200px] overflow-y-auto">
-            <SelectGroup>
-              {companies?.map((company) => (
-                <SelectItem key={company.id} value={company.id}>
-                  {company.name}
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          </SelectContent>
-        )}
-      </Select>
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder="Search companies..."
+              value={query}
+              onValueChange={setQuery}
+            />
+            <CommandList>
+              <CommandEmpty>
+                {loading
+                  ? "Searching..."
+                  : term
+                    ? "No companies found."
+                    : "Type to search companies."}
+              </CommandEmpty>
+
+              {ownFiltered.length > 0 && (
+                <CommandGroup heading="Your companies">
+                  {ownFiltered.map((company) => (
+                    <CommandItem
+                      key={company.id}
+                      value={company.id}
+                      onSelect={() => handleSelect(company)}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4",
+                          value === company.id ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      <span className="truncate">{company.name}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+
+              {otherResults.length > 0 && (
+                <CommandGroup heading="All companies">
+                  {otherResults.map((company) => (
+                    <CommandItem
+                      key={company.id}
+                      value={company.id}
+                      onSelect={() => handleSelect(company)}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4",
+                          value === company.id ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      <span className="truncate">{company.name}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
 
       <AddCompanyButton redirect={false} />
     </div>

--- a/apps/cursor/src/components/company/company-select.tsx
+++ b/apps/cursor/src/components/company/company-select.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Check, ChevronsUpDown } from "lucide-react";
-import { parseAsBoolean, useQueryStates } from "nuqs";
+import { parseAsBoolean, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,9 +42,10 @@ export function CompanySelect({
   const [results, setResults] = useState<Company[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const [{ reload }, setQueryStates] = useQueryStates({
+  const [{ reload, pickedCompany }, setQueryStates] = useQueryStates({
     reload: parseAsBoolean.withDefault(false),
     addCompany: parseAsBoolean.withDefault(false),
+    pickedCompany: parseAsString,
   });
 
   // Load the current user's own companies (shown first). Re-runs when a new
@@ -82,6 +83,17 @@ export function CompanySelect({
       active = false;
     };
   }, [reload, supabase, setQueryStates]);
+
+  // The "Add company" modal reports the chosen company (an existing match or a
+  // freshly created one) via `pickedCompany`. Select it into this field.
+  useEffect(() => {
+    if (!pickedCompany) {
+      return;
+    }
+
+    onChange(pickedCompany);
+    setQueryStates({ pickedCompany: null });
+  }, [pickedCompany, onChange, setQueryStates]);
 
   // Resolve the display name for the currently selected company id, even when
   // it was created by someone else and isn't in the user's own list.

--- a/apps/cursor/src/components/forms/company.tsx
+++ b/apps/cursor/src/components/forms/company.tsx
@@ -2,9 +2,10 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { nanoid } from "nanoid";
+import { useRouter } from "next/navigation";
 import { useAction } from "next-safe-action/hooks";
-import { parseAsBoolean, useQueryState } from "nuqs";
-import { useState } from "react";
+import { parseAsBoolean, parseAsString, useQueryStates } from "nuqs";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { upsertCompanyAction } from "@/actions/upsert-company";
@@ -21,6 +22,10 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  type CompanySearchResult,
+  searchCompanies,
+} from "@/data/client-queries";
 import UploadLogo from "../upload-logo";
 
 const formSchema = z.object({
@@ -74,16 +79,32 @@ export function CompanyForm({
   data?: CompanyData;
   redirect?: boolean;
 }) {
-  const [_, setReload] = useQueryState(
-    "reload",
-    parseAsBoolean.withDefault(false),
-  );
+  const router = useRouter();
+
+  const [, setQueryStates] = useQueryStates({
+    reload: parseAsBoolean.withDefault(false),
+    addCompany: parseAsBoolean.withDefault(false),
+    // Channel used to report the chosen company back to the calling selector
+    // (e.g. the MCP form's CompanySelect).
+    pickedCompany: parseAsString,
+  });
+
+  // Existing-company suggestions for the name field, so users can jump to a
+  // company someone else already added instead of creating a duplicate.
+  const isNewCompany = !data?.id;
+  const [suggestions, setSuggestions] = useState<CompanySearchResult[]>([]);
+  const [suggestionsOpen, setSuggestionsOpen] = useState(false);
 
   const { execute, isExecuting } = useAction(upsertCompanyAction, {
-    onSuccess: () => {
+    onSuccess: ({ data: result }) => {
       if (!redirect) {
-        // Refresh for the new company to be visible in job form
-        setReload(true);
+        // Select the new (or reused) company into the calling form, refresh the
+        // owned-company list, and close the modal.
+        setQueryStates({
+          reload: true,
+          pickedCompany: result?.id ?? null,
+          addCompany: false,
+        });
       }
     },
   });
@@ -105,6 +126,34 @@ export function CompanyForm({
     },
   });
 
+  const nameValue = form.watch("name");
+
+  useEffect(() => {
+    if (!isNewCompany) {
+      return;
+    }
+
+    const term = (nameValue ?? "").trim();
+
+    if (term.length < 2) {
+      setSuggestions([]);
+      return;
+    }
+
+    let active = true;
+    const handle = setTimeout(async () => {
+      const results = await searchCompanies(term, 5);
+      if (active) {
+        setSuggestions(results);
+      }
+    }, 200);
+
+    return () => {
+      active = false;
+      clearTimeout(handle);
+    };
+  }, [nameValue, isNewCompany]);
+
   const onSubmit = (data: z.infer<typeof formSchema>) => {
     execute({
       id,
@@ -121,6 +170,21 @@ export function CompanyForm({
 
   const handleImageUpload = (url: string) => {
     form.setValue("image", url);
+  };
+
+  const handleSuggestionSelect = (company: CompanySearchResult) => {
+    setSuggestions([]);
+    setSuggestionsOpen(false);
+
+    if (redirect) {
+      // Browsing context (e.g. the /companies page): open the existing company.
+      router.push(`/c/${company.slug}`);
+      return;
+    }
+
+    // Selector context (e.g. the MCP form): pick the existing company instead
+    // of creating a duplicate, then close the modal.
+    setQueryStates({ pickedCompany: company.id, addCompany: false });
   };
 
   return (
@@ -141,11 +205,53 @@ export function CompanyForm({
                 <FormItem>
                   <FormLabel>Company Name</FormLabel>
                   <FormControl>
-                    <Input
-                      placeholder="Your company name"
-                      {...field}
-                      className="placeholder:text-[#878787] border-border"
-                    />
+                    <div className="relative">
+                      <Input
+                        placeholder="Your company name"
+                        {...field}
+                        autoComplete="off"
+                        onFocus={() => setSuggestionsOpen(true)}
+                        onBlur={() => {
+                          field.onBlur();
+                          // Delay so a suggestion click registers before hiding.
+                          setTimeout(() => setSuggestionsOpen(false), 150);
+                        }}
+                        className="placeholder:text-[#878787] border-border"
+                      />
+
+                      {isNewCompany &&
+                        suggestionsOpen &&
+                        suggestions.length > 0 && (
+                          <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-md border border-border bg-popover shadow-md">
+                            <div className="px-3 py-2 text-xs text-[#878787]">
+                              Already on Cursor Directory
+                            </div>
+                            <ul className="max-h-[200px] overflow-y-auto">
+                              {suggestions.map((company) => (
+                                <li key={company.id}>
+                                  <button
+                                    type="button"
+                                    onMouseDown={(e) => e.preventDefault()}
+                                    onClick={() =>
+                                      handleSuggestionSelect(company)
+                                    }
+                                    className="flex w-full flex-col items-start px-3 py-2 text-left text-sm transition-colors hover:bg-accent"
+                                  >
+                                    <span className="font-medium text-foreground">
+                                      {company.name}
+                                    </span>
+                                    {company.location && (
+                                      <span className="text-xs text-[#878787]">
+                                        {company.location}
+                                      </span>
+                                    )}
+                                  </button>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                    </div>
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/apps/cursor/src/components/forms/company.tsx
+++ b/apps/cursor/src/components/forms/company.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { nanoid } from "nanoid";
 import { useAction } from "next-safe-action/hooks";
 import { parseAsBoolean, useQueryState } from "nuqs";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { upsertCompanyAction } from "@/actions/upsert-company";
@@ -87,7 +88,9 @@ export function CompanyForm({
     },
   });
 
-  const id = data?.id ?? nanoid();
+  // Generate the id once per mount. Recomputing it on every render would change
+  // the submitted id (and logo upload path) and defeat duplicate prevention.
+  const [id] = useState(() => data?.id ?? nanoid());
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),

--- a/apps/cursor/src/components/forms/company.tsx
+++ b/apps/cursor/src/components/forms/company.tsx
@@ -2,7 +2,6 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { nanoid } from "nanoid";
-import { useRouter } from "next/navigation";
 import { useAction } from "next-safe-action/hooks";
 import { parseAsBoolean, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useState } from "react";
@@ -79,8 +78,6 @@ export function CompanyForm({
   data?: CompanyData;
   redirect?: boolean;
 }) {
-  const router = useRouter();
-
   const [, setQueryStates] = useQueryStates({
     reload: parseAsBoolean.withDefault(false),
     addCompany: parseAsBoolean.withDefault(false),
@@ -89,8 +86,8 @@ export function CompanyForm({
     pickedCompany: parseAsString,
   });
 
-  // Existing-company suggestions for the name field, so users can jump to a
-  // company someone else already added instead of creating a duplicate.
+  // Existing-company suggestions for the name field, so users can reuse a
+  // company that's already on the directory instead of creating a duplicate.
   const isNewCompany = !data?.id;
   const [suggestions, setSuggestions] = useState<CompanySearchResult[]>([]);
   const [suggestionsOpen, setSuggestionsOpen] = useState(false);
@@ -177,8 +174,12 @@ export function CompanyForm({
     setSuggestionsOpen(false);
 
     if (redirect) {
-      // Browsing context (e.g. the /companies page): open the existing company.
-      router.push(`/c/${company.slug}`);
+      // Profile / browse context: complete the name field with the chosen
+      // company instead of navigating away.
+      form.setValue("name", company.name, {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
       return;
     }
 

--- a/apps/cursor/src/components/ui/command.tsx
+++ b/apps/cursor/src/components/ui/command.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import type { DialogProps } from "@radix-ui/react-dialog";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
+import * as React from "react";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+Command.displayName = CommandPrimitive.displayName;
+
+const CommandDialog = ({ children, ...props }: DialogProps) => {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  </div>
+));
+
+CommandInput.displayName = CommandPrimitive.Input.displayName;
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    {...props}
+  />
+));
+
+CommandList.displayName = CommandPrimitive.List.displayName;
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="py-6 text-center text-sm"
+    {...props}
+  />
+));
+
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
+
+const CommandSeparator = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      className,
+    )}
+    {...props}
+  />
+));
+
+CommandItem.displayName = CommandPrimitive.Item.displayName;
+
+const CommandShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+CommandShortcut.displayName = "CommandShortcut";
+
+export {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+};

--- a/apps/cursor/src/data/client-queries.ts
+++ b/apps/cursor/src/data/client-queries.ts
@@ -12,7 +12,7 @@ export type CompanySearchResult = {
 // filtering an already-loaded page of results.
 export async function searchCompanies(
   term: string,
-  limit = 200,
+  limit?: number,
 ): Promise<CompanySearchResult[]> {
   const trimmed = term.trim();
 
@@ -21,21 +21,45 @@ export async function searchCompanies(
   }
 
   const supabase = createClient();
+  const baseQuery = () =>
+    supabase
+      .from("companies")
+      .select("id, name, slug, image, location")
+      .ilike("name", `%${trimmed}%`)
+      .order("name", { ascending: true });
 
-  const { data } = await supabase
-    .from("companies")
-    .select("id, name, slug, image, location")
-    .ilike("name", `%${trimmed}%`)
-    .order("name", { ascending: true })
-    .limit(limit);
+  if (limit !== undefined) {
+    const { data } = await baseQuery().limit(limit);
+    return (data ?? []).map((company) => ({
+      id: company.id,
+      name: company.name,
+      slug: company.slug,
+      image: company.image ?? "",
+      location: company.location ?? "",
+    }));
+  }
 
-  return (data ?? []).map((company) => ({
-    id: company.id,
-    name: company.name,
-    slug: company.slug,
-    image: company.image ?? "",
-    location: company.location ?? "",
-  }));
+  const PAGE_SIZE = 1000;
+  const all: CompanySearchResult[] = [];
+  let from = 0;
+
+  while (true) {
+    const { data } = await baseQuery().range(from, from + PAGE_SIZE - 1);
+    if (!data || data.length === 0) break;
+    all.push(
+      ...data.map((company) => ({
+        id: company.id,
+        name: company.name,
+        slug: company.slug,
+        image: company.image ?? "",
+        location: company.location ?? "",
+      })),
+    );
+    if (data.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+
+  return all;
 }
 
 export async function getMCPsClient({

--- a/apps/cursor/src/data/client-queries.ts
+++ b/apps/cursor/src/data/client-queries.ts
@@ -1,5 +1,43 @@
 import { createClient } from "@/utils/supabase/client";
 
+export type CompanySearchResult = {
+  id: string;
+  name: string;
+  slug: string;
+  image: string;
+  location: string;
+};
+
+// Searches the entire companies table by name (case-insensitive), rather than
+// filtering an already-loaded page of results.
+export async function searchCompanies(
+  term: string,
+  limit = 200,
+): Promise<CompanySearchResult[]> {
+  const trimmed = term.trim();
+
+  if (!trimmed) {
+    return [];
+  }
+
+  const supabase = createClient();
+
+  const { data } = await supabase
+    .from("companies")
+    .select("id, name, slug, image, location")
+    .ilike("name", `%${trimmed}%`)
+    .order("name", { ascending: true })
+    .limit(limit);
+
+  return (data ?? []).map((company) => ({
+    id: company.id,
+    name: company.name,
+    slug: company.slug,
+    image: company.image ?? "",
+    location: company.location ?? "",
+  }));
+}
+
 export async function getMCPsClient({
   page = 1,
   limit = 36,

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "directories",
@@ -33,6 +32,7 @@
         "@vercel/firewall": "^1.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "framer-motion": "^12.38.0",
         "fuse.js": "^7.3.0",
@@ -415,6 +415,8 @@
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
 

--- a/supabase/migrations/20260526_companies_name_trgm.sql
+++ b/supabase/migrations/20260526_companies_name_trgm.sql
@@ -1,0 +1,6 @@
+-- Speed up case-insensitive substring search (ILIKE '%term%') used by the
+-- company search/typeahead, which a plain btree index cannot serve.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS companies_name_trgm
+  ON public.companies USING gin (name gin_trgm_ops);

--- a/supabase/migrations/20260526_companies_unique_name.sql
+++ b/supabase/migrations/20260526_companies_unique_name.sql
@@ -1,0 +1,11 @@
+-- Normalize existing names so surrounding whitespace can't create near-duplicates
+UPDATE public.companies SET name = btrim(name) WHERE name <> btrim(name);
+
+-- Normalized key used to enforce case-insensitive uniqueness of company names
+ALTER TABLE public.companies
+  ADD COLUMN IF NOT EXISTS name_key text
+  GENERATED ALWAYS AS (lower(btrim(name))) STORED;
+
+-- One company per normalized name (prevents the duplicate explosion at the DB level)
+CREATE UNIQUE INDEX IF NOT EXISTS companies_name_key_unique
+  ON public.companies (name_key);


### PR DESCRIPTION
## Summary

Companies were being duplicated heavily (e.g. 7 separate "Contentful" rows, ~260 duplicate rows in total) because company creation only de-duped on a freshly-minted client-side id while a `BEFORE INSERT` trigger silently uniquified slugs (`contentful-1`, `contentful-2`, …). This PR fixes the root cause and makes existing companies pickable so users don't need to re-create them.

### Prevent duplicate company records
- New migration `supabase/migrations/20260526_companies_unique_name.sql`: normalizes existing names, adds a generated `name_key` column, and a **case-insensitive unique index** so duplicates are rejected at the DB level even under concurrent/double submits.
- `upsert-company` action: treats a request as an edit only when the row already exists, and **reuses** the existing company on a name conflict (idempotent) instead of creating a duplicate.
- Company form: generates the id once per mount so it stops changing on every render (which also broke the logo upload path).

### Searchable company picker
- Replaces the owner-only company dropdown with a searchable combobox (shadcn `Command` + `Popover`, adds `cmdk`).
- Searches across all companies (RLS allows public read), with the user's own companies listed first and "Add company" kept as the fallback.
- This closes the gap the unique constraint would otherwise create: if a colleague already submitted the company, you can now find and select it instead of being blocked.

## Test plan
- [ ] Submitting the same company name twice (incl. rapid double-click) resolves to one company instead of duplicates.
- [ ] Editing an existing company still works and preserves its slug.
- [ ] In the MCP form, searching the company picker surfaces companies created by other users; selecting one attaches it.
- [ ] "Add company" for a brand-new name creates it; for an existing name it reuses the existing record.

## Notes for reviewers
- The migration and a one-time cleanup of the 260 pre-existing duplicate rows were already applied to the production DB. The cleanup is reversible via the `companies_dedup_backup_20260526` table (each row records the canonical id it was merged into).
- OG-image/rate-limit changes that previously shared a branch with this work are **not** included here — those landed separately in main via #398. This branch is company-changes only.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading state plus broader read queries on public company data; no auth or write-path changes in this diff.
> 
> **Overview**
> Improves the **companies directory search** UX and removes the implicit **200-result cap** on full-table name search.
> 
> `CompanyList` now tracks **`isSearching`** during the debounced `searchCompanies` call, showing a **"Searching..."** state instead of briefly treating an empty list as **no results** (and no longer clearing the grid at search start).
> 
> `searchCompanies` takes an optional **`limit`**: when provided (e.g. form suggestions still use **`5`**), behavior is unchanged; when omitted, it **pages through Supabase in 1000-row chunks** until all name matches are returned, so the companies page can show every match—not only the first 200.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75f377affb898d4b82c0fa1c4b108ba8bfb237c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->