### PR TITLE
Fix plugin update failing on over-length component slugs

### DIFF
--- a/apps/cursor/src/actions/update-plugin.ts
+++ b/apps/cursor/src/actions/update-plugin.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { enqueuePluginScan, kickDrainAfterResponse } from "@/lib/plugins/queue";
 import { pluginScanLimit } from "@/lib/rate-limit";
+import { resolveComponentSlug } from "@/lib/slug";
 import { createClient } from "@/utils/supabase/admin-client";
 import { ActionError, authActionClient } from "./safe-action";
 
@@ -36,13 +37,6 @@ type ExistingComponent = {
   sort_order: number;
 };
 
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
 function componentKey(type: string, slug: string): string {
   return `${type}:${slug}`;
 }
@@ -57,7 +51,7 @@ function fingerprintComponent(c: {
   content?: string | null;
   metadata?: Record<string, unknown> | null;
 }): string {
-  const slug = c.slug || slugify(c.name);
+  const slug = resolveComponentSlug(c);
   return JSON.stringify({
     type: c.type,
     slug,
@@ -70,7 +64,7 @@ function resolveComponentMetadata(
   comp: ComponentInput,
   prevByKey: Map<string, ExistingComponent>,
 ): Record<string, unknown> {
-  const slug = comp.slug || slugify(comp.name);
+  const slug = resolveComponentSlug(comp);
   const submitted = comp.metadata;
   if (submitted && Object.keys(submitted).length > 0) {
     return submitted;
@@ -99,7 +93,7 @@ function installRelevantChanged(
     .sort();
   const prevByKey = new Map(
     prevComponents.map((c) => [
-      componentKey(c.type, c.slug || slugify(c.name)),
+      componentKey(c.type, resolveComponentSlug(c)),
       c,
     ]),
   );
@@ -201,7 +195,7 @@ export const updatePluginAction = authActionClient
 
       const prevByKey = new Map(
         prevComponents.map((c) => [
-          componentKey(c.type, c.slug || slugify(c.name)),
+          componentKey(c.type, resolveComponentSlug(c)),
           c,
         ]),
       );
@@ -210,7 +204,7 @@ export const updatePluginAction = authActionClient
         plugin_id: id,
         type: comp.type,
         name: comp.name,
-        slug: comp.slug || slugify(comp.name),
+        slug: resolveComponentSlug(comp),
         description: comp.description || null,
         content: comp.content || null,
         metadata: resolveComponentMetadata(comp, prevByKey),

--- a/apps/cursor/src/components/forms/edit-plugin-form.tsx
+++ b/apps/cursor/src/components/forms/edit-plugin-form.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { slugify } from "@/lib/slug";
 import type { PluginRow } from "@/data/queries";
 import UploadLogo from "../upload-logo";
 
@@ -45,13 +46,6 @@ type EditableComponent = {
   description: string;
   content: string;
 };
-
-function slugify(value: string) {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
 
 export function EditPluginForm({ data }: { data: PluginRow }) {
   const [name, setName] = useState(data.name);

--- a/apps/cursor/src/components/forms/plugin-form.tsx
+++ b/apps/cursor/src/components/forms/plugin-form.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { slugify } from "@/lib/slug";
 import UploadLogo from "../upload-logo";
 
 const COMPONENT_TYPES = [
@@ -83,13 +84,6 @@ type ManualComponent = {
   description: string;
   content: string;
 };
-
-function slugify(value: string) {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
 
 const autoFormSchema = z.object({
   url: z

--- a/apps/cursor/src/lib/github-plugin/parse.ts
+++ b/apps/cursor/src/lib/github-plugin/parse.ts
@@ -8,6 +8,8 @@
  * endpoints from 60 req/h (unauth) to 5,000 req/h (auth).
  */
 
+import { slugify } from "@/lib/slug";
+
 export type ParsedComponent = {
   type: string;
   name: string;
@@ -44,22 +46,6 @@ export class GitHubParseError extends Error {
     super(message);
     this.name = "GitHubParseError";
   }
-}
-
-// Cap component slugs so the resulting filenames stay under typical
-// filesystem name limits (255 bytes). Vercel writes per-slug prerender
-// configs (e.g. `<slug>.prerender-config.json`), so a very long slug breaks
-// the build with ENAMETOOLONG. 80 chars leaves ample headroom for suffixes.
-const MAX_SLUG_LENGTH = 80;
-
-function slugify(value: string) {
-  return value
-    .toLowerCase()
-    .replace(/['".]/g, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, MAX_SLUG_LENGTH)
-    .replace(/-+$/g, "");
 }
 
 function parseFrontmatter(input: string): {

--- a/apps/cursor/src/lib/plugins/insert.ts
+++ b/apps/cursor/src/lib/plugins/insert.ts
@@ -8,6 +8,7 @@
  */
 
 import { enqueuePluginScan, kickDrainAfterResponse } from "@/lib/plugins/queue";
+import { resolveComponentSlug } from "@/lib/slug";
 import { createClient } from "@/utils/supabase/admin-client";
 
 type ComponentInput = {
@@ -61,20 +62,6 @@ export class InsertPluginError extends Error {
     super(message);
     this.name = "InsertPluginError";
   }
-}
-
-// Match the cap used by the GitHub parser's slugify so user submissions and
-// the seed pipeline produce slugs in the same shape, and so neither path can
-// blow past filesystem name limits when Next.js prerenders per-slug routes.
-const MAX_SLUG_LENGTH = 80;
-
-function fallbackSlug(value: string) {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, MAX_SLUG_LENGTH)
-    .replace(/-+$/g, "");
 }
 
 export async function insertPlugin(
@@ -134,7 +121,7 @@ export async function insertPlugin(
     plugin_id: plugin.id,
     type: comp.type,
     name: comp.name,
-    slug: (comp.slug || fallbackSlug(comp.name)).slice(0, MAX_SLUG_LENGTH),
+    slug: resolveComponentSlug(comp),
     description: comp.description || null,
     content: comp.content || null,
     metadata: comp.metadata || {},

--- a/apps/cursor/src/lib/slug.ts
+++ b/apps/cursor/src/lib/slug.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared slug helpers for plugins and their components.
+ *
+ * Pure module (no server-only deps) so it's safe to import from client forms,
+ * server actions, the GitHub parser, and seed scripts alike.
+ */
+
+// Cap slugs at 80 chars. The per-slug API routes (e.g. `/api/[slug]`) are
+// `force-static`, so Vercel writes a `<slug>.prerender-config.json` file per
+// known slug at build time; a longer slug blows past the 255-byte filesystem
+// name limit (ENAMETOOLONG) and breaks the build. It also satisfies the
+// `plugin_components_slug_length_check` Postgres constraint. 80 chars leaves
+// ample headroom for disambiguating suffixes.
+export const MAX_SLUG_LENGTH = 80;
+
+/**
+ * Derive a URL/filename-safe slug from arbitrary text, capped at
+ * `MAX_SLUG_LENGTH`. Quotes and dots are dropped (so `react.js` → `reactjs`)
+ * rather than turned into separators.
+ */
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/['".]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/g, "");
+}
+
+/**
+ * Resolve a component's effective slug: an explicit slug if provided, else one
+ * derived from its name. Always capped so DB writes satisfy the length
+ * constraint and rescan-diff keys match the value stored on the row.
+ */
+export function resolveComponentSlug(comp: {
+  slug?: string | null;
+  name: string;
+}): string {
+  if (comp.slug) {
+    return comp.slug.slice(0, MAX_SLUG_LENGTH).replace(/-+$/g, "");
+  }
+  return slugify(comp.name);
+}


### PR DESCRIPTION
The update path built component slugs without the 80-char cap that creation applies, so editing a plugin whose component name slugifies to >80 chars violated the plugin_components_slug_length_check constraint.

Consolidate the duplicated slugify/cap logic (previously in insert.ts, update-plugin.ts, parse.ts, and both plugin forms) into a shared lib/slug.ts util so every path enforces the cap consistently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor consolidates slug logic with no auth or schema changes; behavior change is enforcing an existing length constraint on update.
> 
> **Overview**
> Fixes plugin **updates** failing when a component name slugifies to more than 80 characters by routing all server-side slug resolution through shared helpers instead of uncapped local `slugify` logic on the update path.
> 
> Introduces **`@/lib/slug`** with `MAX_SLUG_LENGTH` (80), `slugify`, and `resolveComponentSlug` so create, update, GitHub parse, and client forms all enforce the same cap and normalization (quotes/dots stripped, trailing hyphens trimmed). **Update** and **insert** paths now persist slugs via `resolveComponentSlug`; forms and the parser import the shared `slugify` and drop duplicated implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcd9c7d9ac913d1da5c2ada589862c3bf3c6109e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->