### PR TITLE
Preserve stored component slugs in the plugin edit form

### DIFF
--- a/apps/cursor/src/components/forms/edit-plugin-form.tsx
+++ b/apps/cursor/src/components/forms/edit-plugin-form.tsx
@@ -42,6 +42,15 @@ const COMPONENT_LABELS: Record<string, string> = {
 type EditableComponent = {
   id: string;
   type: (typeof COMPONENT_TYPES)[number];
+  /**
+   * Stored DB slug, empty for components added in this session. Preserved
+   * through the round-trip because regenerating from `name` produces a
+   * different slug whenever name and slug were derived from different
+   * sources (GitHub-imported rules slugify the filename but use the
+   * frontmatter title/description as the name), which churns slugs, breaks
+   * the rescan diff, and drops metadata keyed by the old slug.
+   */
+  slug: string;
   name: string;
   description: string;
   content: string;
@@ -61,6 +70,7 @@ export function EditPluginForm({ data }: { data: PluginRow }) {
       .map((c) => ({
         id: crypto.randomUUID(),
         type: c.type as EditableComponent["type"],
+        slug: c.slug,
         name: c.name,
         description: c.description ?? "",
         content: c.content ?? "",
@@ -85,6 +95,7 @@ export function EditPluginForm({ data }: { data: PluginRow }) {
       {
         id: crypto.randomUUID(),
         type: "rule",
+        slug: "",
         name: "",
         description: "",
         content: "",
@@ -133,7 +144,7 @@ export function EditPluginForm({ data }: { data: PluginRow }) {
       components: validComponents.map((c) => ({
         type: c.type,
         name: c.name.trim(),
-        slug: slugify(c.name),
+        slug: c.slug || slugify(c.name),
         description: c.description.trim() || undefined,
         content: c.content.trim() || undefined,
       })),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #403

## Context

Issue #403 reported two problems with the plugin update path:

1. The `slugify` helpers in `edit-plugin-form.tsx` / `update-plugin.ts` were missing the 80-char cap, so updates crashed on the `plugin_components_slug_length_check` constraint. **This was already fixed** by #407 (`bcd9c7d`), which consolidated all slug logic into the shared `lib/slug.ts`.
2. The edit form discards each component's original database `slug` and regenerates it from `name` on submit. **This part was never fixed** and has real consequences beyond the (now-capped) constraint crash.

## Remaining bug

For GitHub-imported plugins, a rule's stored `slug` derives from the `.mdc` filename, while its `name` comes from the frontmatter `title`/`description` (often a full sentence). Since the edit form drops the stored slug and submits `slugify(name)` instead, every save through the edit form:

- **Silently rewrites component slugs**, even on a no-op "Update Plugin" click.
- **Triggers a spurious rescan and deactivates the plugin**: `installRelevantChanged` fingerprints components by `type:slug`, so the slug churn makes every component look changed, flipping `p_deactivate_for_scan` and burning the owner's scan rate limit.
- **Wipes component metadata**: the form never submits `metadata`, and `resolveComponentMetadata` carries the previous row's metadata forward by looking up `type:slug` — keyed by the *new* slug, the lookup misses and metadata (rule tags/globs/`always_apply`, MCP `command`/`args`/`env`/`link`) resets to `{}`.

## Fix

Carry the stored `slug` through `EditableComponent` and submit it unchanged, falling back to `slugify(name)` only for components newly added in the form. The server action (`resolveComponentSlug`) already caps any slug at 80 chars, so the constraint stays satisfied.

This also matches the existing intent in `update-plugin.ts` that cosmetic renames must not trigger a rescan — with a stable slug, renaming a component no longer changes its fingerprint.

## Verification

- `tsc --noEmit` passes.
- `biome check` on the changed file reports the same pre-existing diagnostics as `main` (no new issues).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8133ed10-1703-46e5-ac32-f1b37e135515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8133ed10-1703-46e5-ac32-f1b37e135515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

