### PR TITLE
Fix plugin scans crashing on the sandbox's read-only home dir

### DIFF
--- a/apps/cursor/src/app/api/queue/plugin-scans/drain/route.ts
+++ b/apps/cursor/src/app/api/queue/plugin-scans/drain/route.ts
@@ -14,9 +14,10 @@ import {
 // Vercel max for Pro / Enterprise + Fluid Compute (default since 2025) is 800s.
 // Source: https://vercel.com/docs/functions/configuring-functions/duration
 //
-// The `Agent.prompt` step can take 1–3 minutes for a typical plugin; the git
-// clone is bounded by CLONE_TIMEOUT_MS (60s) inside scan.ts. 800s gives us
-// generous headroom for the worst-case agent run.
+// The `Agent.prompt` step can take 1–3 minutes for a typical plugin; the repo
+// archive download is bounded by REPO_ARCHIVE_MAX_BYTES and a rate-limit
+// retry budget inside scan.ts. 800s gives us generous headroom for the
+// worst-case agent run.
 export const dynamic = "force-dynamic";
 export const maxDuration = 800;
 

--- a/apps/cursor/src/lib/github-plugin/parse.ts
+++ b/apps/cursor/src/lib/github-plugin/parse.ts
@@ -124,7 +124,7 @@ export function parseGitHubUrl(
   return { owner: match[1], repo: match[2] };
 }
 
-function authHeaders(): Record<string, string> {
+export function githubAuthHeaders(): Record<string, string> {
   return process.env.GITHUB_TOKEN
     ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
     : {};
@@ -139,7 +139,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
  * remains safe to call from server actions (which have request timeouts).
  * Bulk scripts can pass a larger budget.
  */
-async function fetchWithRateLimit(
+export async function fetchWithRateLimit(
   url: string,
   init: RequestInit & { maxWaitMs?: number } = {},
 ): Promise<Response> {
@@ -212,7 +212,7 @@ async function fetchGitHubTree(
       cache: "no-store",
       headers: {
         Accept: "application/vnd.github.v3+json",
-        ...authHeaders(),
+        ...githubAuthHeaders(),
       },
       maxWaitMs: opts.maxWaitMs,
     });
@@ -263,7 +263,7 @@ export async function fetchGitHubRepoMeta(
         cache: "no-store",
         headers: {
           Accept: "application/vnd.github.v3+json",
-          ...authHeaders(),
+          ...githubAuthHeaders(),
         },
         maxWaitMs: opts.maxWaitMs,
       },

--- a/apps/cursor/src/lib/plugins/scan.ts
+++ b/apps/cursor/src/lib/plugins/scan.ts
@@ -28,6 +28,10 @@ import type {
   PluginComponent,
   ScanVerdict,
 } from "@/data/queries";
+import {
+  fetchWithRateLimit,
+  githubAuthHeaders,
+} from "@/lib/github-plugin/parse";
 import { createClient } from "@/utils/supabase/admin-client";
 
 /**
@@ -41,6 +45,23 @@ export class FatalScanError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "FatalScanError";
+  }
+}
+
+/**
+ * Terminal repo-fetch failure: GitHub deterministically refuses to serve the
+ * archive (repo deleted/private/DMCA'd, or larger than our scan budget).
+ * Re-fetching won't change the answer, so the scan resolves to a
+ * "suspicious / manual review" verdict instead of retrying. Anything else
+ * thrown during the archive download (DNS, rate limit, GitHub 5xx) is treated
+ * as transient and bubbles out so the queue redelivers the message — an infra
+ * hiccup must not permanently flag a legitimate plugin (see
+ * cursor/community-plugins#395).
+ */
+class UnscannableRepoError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnscannableRepoError";
   }
 }
 
@@ -292,6 +313,39 @@ async function applyBlockedShortCircuit(pluginId: string) {
 // other step executions and have a hard ~500MB limit on Vercel.
 const REPO_ARCHIVE_MAX_BYTES = 100 * 1024 * 1024;
 
+// The Vercel function sandbox only guarantees a writable /tmp; os.homedir()
+// points at a path that may not exist or be read-only (`/home/sbx_user...`).
+// The Cursor SDK persists local-agent state under `~/.cursor/projects/...` by
+// default, which crashed every scan with `mkdir ENOENT` (see
+// cursor/community-plugins#395). A single stable dir — not per-scan — so a
+// warm function instance reuses one run store instead of opening a new
+// sqlite handle per scan.
+const SDK_STATE_HOME = path.join(tmpdir(), "cursor-sdk-home");
+
+/**
+ * Point every Cursor SDK state surface at writable tmpfs and return the
+ * `stateRoot` to pass to `Agent.prompt`:
+ *
+ * - `platform.stateRoot` covers the SDK's in-process run/checkpoint stores
+ *   (the `sdk-agent-store` path that failed in production).
+ * - `HOME` / `CURSOR_CONFIG_DIR` / `CURSOR_DATA_DIR` cover the spawned
+ *   `cursor-agent` process and the SDK's remaining `homedir()` fallbacks.
+ *
+ * Mutating `process.env` is safe here: this module only runs inside the
+ * drain route's function, and the values are constants so concurrent
+ * invocations in a shared instance can't observe a mix.
+ */
+async function redirectSdkStateToTmp(): Promise<string> {
+  const cursorDir = path.join(SDK_STATE_HOME, ".cursor");
+  const stateRoot = path.join(SDK_STATE_HOME, "sdk-agent-store");
+  process.env.HOME = SDK_STATE_HOME;
+  process.env.CURSOR_CONFIG_DIR = cursorDir;
+  process.env.CURSOR_DATA_DIR = cursorDir;
+  await mkdir(cursorDir, { recursive: true });
+  await mkdir(stateRoot, { recursive: true });
+  return stateRoot;
+}
+
 function archiveSizeGuard(tag: string) {
   let downloaded = 0;
   return new Transform({
@@ -299,8 +353,8 @@ function archiveSizeGuard(tag: string) {
       downloaded += chunk.length;
       if (downloaded > REPO_ARCHIVE_MAX_BYTES) {
         callback(
-          new Error(
-            `Repository archive exceeded ${REPO_ARCHIVE_MAX_BYTES} bytes.`,
+          new UnscannableRepoError(
+            `Repository archive exceeded the ${REPO_ARCHIVE_MAX_BYTES}-byte scan limit.`,
           ),
         );
         return;
@@ -329,12 +383,22 @@ async function cloneRepo(
   logInfo(tag, "GitHub archive download start", { owner, repo, cwd });
   try {
     await mkdir(cwd);
-    const response = await fetch(archiveUrl, {
+    // GITHUB_TOKEN (when configured) lifts the 60 req/hr anonymous rate limit
+    // shared across all tenants of the function's egress IP.
+    const response = await fetchWithRateLimit(archiveUrl, {
       headers: {
         Accept: "application/vnd.github+json",
         "User-Agent": "cursor-directory-plugin-scan",
+        ...githubAuthHeaders(),
       },
+      maxWaitMs: 30_000,
     });
+
+    if ([404, 410, 451].includes(response.status)) {
+      throw new UnscannableRepoError(
+        `GitHub returned ${response.status} for ${owner}/${repo} — the repository does not exist or is not public.`,
+      );
+    }
 
     if (!response.ok || !response.body) {
       throw new Error(
@@ -347,8 +411,8 @@ async function cloneRepo(
       contentLength &&
       Number.parseInt(contentLength, 10) > REPO_ARCHIVE_MAX_BYTES
     ) {
-      throw new Error(
-        `Repository archive advertised ${contentLength} bytes, above ${REPO_ARCHIVE_MAX_BYTES}.`,
+      throw new UnscannableRepoError(
+        `Repository archive advertised ${contentLength} bytes, above the ${REPO_ARCHIVE_MAX_BYTES}-byte scan limit.`,
       );
     }
 
@@ -418,24 +482,33 @@ async function runSecurityAgent(
       logInfo(tag, "no repo URL; using empty cwd", { cwd });
     }
   } catch (err) {
-    logError(tag, "clone setup failed; returning suspicious verdict", err);
-    return {
-      verdict: "suspicious",
-      severity: "low",
-      categories: [],
-      reasons: ["repository_clone_failed"],
-      summary: `Could not clone ${plugin.repository}: ${err instanceof Error ? err.message : String(err)}. Manual review required.`,
-      runId: null,
-    };
+    if (err instanceof UnscannableRepoError) {
+      logError(tag, "repo unscannable; returning suspicious verdict", err);
+      return {
+        verdict: "suspicious",
+        severity: "low",
+        categories: [],
+        reasons: ["repository_clone_failed"],
+        summary: `Could not fetch ${plugin.repository}: ${err.message} Manual review required.`,
+        runId: null,
+      };
+    }
+    // Transient failure (network, rate limit, GitHub 5xx): rethrow so the
+    // drain route leaves the message for pgmq to redeliver instead of
+    // permanently flagging the plugin over an infra hiccup.
+    logError(tag, "repo fetch failed; treating as retryable", err);
+    throw err;
   }
 
   try {
+    const stateRoot = await redirectSdkStateToTmp();
     const prompt = buildPrompt(plugin, { hasRepo, similar });
     logInfo(tag, "Agent.prompt start", {
       cwd,
       hasRepo,
       promptChars: prompt.length,
       model: "composer-2",
+      stateRoot,
     });
 
     const agentStartedAt = Date.now();
@@ -446,6 +519,11 @@ async function runSecurityAgent(
         model: { id: "composer-2" },
         local: { cwd },
         name: `scan:${plugin.slug}`,
+        // Keep the SDK's run store off the (read-only) default home dir.
+        // `CursorAgentPlatformOptions` isn't shipped with the SDK's types,
+        // so this field is typed as `any` — the runtime contract is
+        // `{ stateRoot?: string; workspaceRef?: string }`.
+        platform: { stateRoot },
       });
     } catch (err) {
       if (err instanceof CursorAgentError && err.isRetryable) {


### PR DESCRIPTION
## Summary

Fixes #395.

Every plugin security scan has failed since late May because the Vercel function sandbox stopped providing a writable home directory (and a `git` binary — the tarball download in #402 fixed that half). Two failure generations:

1. `spawn git ENOENT` → plugins permanently **flagged** with `repository_clone_failed` (~40 listings hidden).
2. After #402: the Cursor SDK's local runtime persists its run store under `~/.cursor/projects/<ws>/sdk-agent-store/<hash>`, so `Agent.prompt` crashed with `ENOENT: mkdir '/home/sbx_user1051/...'` → every scan since May 28 ends in `scan_status='error'` (~90 plugins, all submissions affected).

### Changes

- **Redirect all Cursor SDK state to tmpfs** (`/tmp` is the only writable path in the sandbox): `platform.stateRoot` for the SDK's in-process run/checkpoint stores, plus `HOME` / `CURSOR_CONFIG_DIR` / `CURSOR_DATA_DIR` for the spawned `cursor-agent` process and remaining `homedir()` fallbacks. Stable dir (not per-scan) so warm instances reuse one sqlite store.
- **Stop permanently flagging plugins over transient infra failures.** Only deterministic refusals (`404`/`410`/`451`, archive above the 100MB cap) resolve to the `suspicious` / manual-review verdict. Network errors, rate limits, and GitHub 5xx now bubble out as retryable, so the pgmq visibility timeout redelivers the scan instead of hiding a legitimate listing.
- **Authenticate the tarball download** with `GITHUB_TOKEN` (when configured) and reuse the shared rate-limit retry helper — anonymous GitHub API calls from shared egress IPs cap at 60 req/hr.

### Verification

- Simulated the broken sandbox locally (`HOME` pointed at an uncreatable path): without `platform.stateRoot` the SDK targets `$HOME/.cursor/...`; with the override it creates its sqlite store under `/tmp` and proceeds (verified `index.db` created, run continues to auth stage).
- Exercised the new fetch paths: nonexistent repo → `UnscannableRepoError` → manual-review verdict; `contentful/skills` (from the issue thread) downloads and extracts.
- `tsc --noEmit` and `biome check` clean for the touched files (one pre-existing, unrelated failure on `main` in each).

### Post-deploy ops (not in this PR)

The ~130 plugins stuck in `flagged (repository_clone_failed)` / `error (Cursor SDK startup failed)` need a re-enqueue once this deploys (reset `scan_status='pending'` + `pgmq send`); the previously reported `update_plugin_with_components` schema-cache error was resolved by the `20260528192856 atomic_plugin_update` migration already applied in prod.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the plugin security scan pipeline and listing visibility (verdict vs queue retry), but changes are narrowly scoped error handling and sandbox configuration rather than scan logic or auth.
> 
> **Overview**
> Fixes plugin security scans failing on Vercel because the Cursor SDK tried to write run state under a **read-only sandbox home directory**. Before `Agent.prompt`, scans now call **`redirectSdkStateToTmp()`**, which sets `HOME` / `CURSOR_CONFIG_DIR` / `CURSOR_DATA_DIR` and passes **`platform.stateRoot`** under `/tmp` so the SDK and spawned `cursor-agent` use writable tmpfs.
> 
> **Repo fetch behavior is split** so infra blips do not permanently flag plugins. A new **`UnscannableRepoError`** covers deterministic GitHub refusals (404/410/451, archive over the 100MB cap) and still resolves to a **suspicious / manual-review** verdict. Network, rate limits, and other transient download failures **rethrow** so the drain route leaves the queue message for redelivery. Tarball downloads now use the shared **`fetchWithRateLimit`** and **`githubAuthHeaders`** (exported from `github-plugin/parse.ts`) when `GITHUB_TOKEN` is set.
> 
> The drain route comment is updated to describe archive download limits instead of git clone timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61dc158b387bd3c57298197c9548114e495e4de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->