### PR TITLE
Use submitted name if possible and server as fallback for MCP installation

### DIFF
--- a/apps/cursor/src/components/plugins/detail/mcp-section.tsx
+++ b/apps/cursor/src/components/plugins/detail/mcp-section.tsx
@@ -12,7 +12,7 @@ import { buildMCPInstallDeepLink } from "./deeplinks";
 function resolveMcpConfig(
   content: string | null,
   meta: Record<string, unknown>,
-): { name: string; config: Record<string, unknown> } | null {
+): { config: Record<string, unknown> } | null {
   // Try content first, then metadata.config
   let parsed: Record<string, unknown> | null = null;
 
@@ -37,14 +37,13 @@ function resolveMcpConfig(
     const keys = Object.keys(servers);
     if (keys.length > 0) {
       return {
-        name: keys[0],
         config: servers[keys[0]] as Record<string, unknown>,
       };
     }
   }
 
   // Content is already a raw config (no mcpServers wrapper)
-  return { name: (meta?.name as string) ?? "server", config: parsed };
+  return { config: parsed };
 }
 
 export function McpSection({
@@ -75,8 +74,9 @@ export function McpSection({
             const serialized = JSON.stringify(resolved.config, null, 2);
             configPreview = serialized;
             if (!installLink) {
+              const installName = mcp.name.trim() || "server";
               installLink = buildMCPInstallDeepLink(
-                resolved.name,
+                installName,
                 JSON.stringify(resolved.config),
               );
             }


### PR DESCRIPTION
## Linked issue:
https://github.com/cursor/community-plugins/issues/416

## Summary
- Fixes MCP install deeplink name selection so it uses the submitted MCP component name instead of defaulting to the config key (often server).
- Preserves previous fallback behaviour by using server when the component name is empty/missing.
- Keeps MCP config payload handling unchanged; only the deeplink name parameter selection is adjusted.

## Problem
When adding an MCP via Add to Cursor, the deeplink name could show as server even when a custom name was provided, because the name was derived from the config structure rather than the component display name.

## Solution
In apps/cursor/src/components/plugins/detail/mcp-section.tsx:
- Stop deriving deeplink name from mcpServers keys.
- Use mcp.name.trim() for install deeplinks.
- Fall back to "server" if that name is blank.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to deeplink `name` query parameter only; no auth, data, or config parsing changes beyond dropping unused name from `resolveMcpConfig`.
> 
> **Overview**
> **MCP “Add to Cursor” install deeplinks** now pass the plugin component’s display name (`mcp.name`) instead of the first `mcpServers` config key (often `server`).
> 
> `resolveMcpConfig` only returns the parsed config; name selection moved to install-link generation with **`mcp.name.trim() || "server"`** when no explicit `mcp_link` is set. Config payload and preview behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dcb9dda23a1e2328090a9c1de89e592015a335a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->